### PR TITLE
Rename portfolio-v2 to portfolio-site

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 services:
   - type: web
-    name: portfolio-v2
+    name: portfolio-site
     env: static
     buildCommand: npm install && npm run build
     staticPublishPath: ./dist


### PR DESCRIPTION
Updates service naming to follow the standard convention where all frontends use `-site` suffix.