### PR TITLE
Add Dockerfile with npm install for compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- Added Dockerfile using `npm install` instead of `npm ci` for better compatibility when package-lock.json may be out of sync with package.json

## Test plan
- [x] Build Docker image locally: `docker build -t portfolio .`
- [x] Verify container runs correctly