### PR TITLE
Add Dockerfile for Docker Compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm install
+
+# Copy source code
+COPY . .
+
+# Expose Vite dev server port
+EXPOSE 5173
+
+# Start development server with host binding for Docker
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- Add Dockerfile to enable `docker compose up --build`
- Use Node.js 20 Alpine for lightweight containers
- Ready for Kubernetes deployment

## Test plan
- [ ] Run `docker compose up --build`
- [ ] Verify service starts correctly