### PR TITLE
feat: Add chatbot CTA with modal between Hero and About

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -8,7 +8,7 @@ import { Skills } from "@/components/sections/Skills"
 import { Projects } from "@/components/sections/Projects"
 import { Contact } from "@/components/sections/Contact"
 import { GlobeSection } from "@/components/sections/GlobeSection"
-import { AskAboutMe } from "@/components/voice-assistant"
+import { AskAboutMe, ChatbotCTA } from "@/components/voice-assistant"
 
 import { FallingBlocksGame } from "@/components/game/FallingBlocksGame"
 import { TetrisGame } from "@/components/game/TetrisGame"
@@ -28,6 +28,7 @@ import { NotFound } from "@/pages/NotFound"
 const Home = () => (
     <div className="min-h-screen">
       <Hero />
+      <ChatbotCTA />
       <About />
       <Skills />
       <Experience />

--- a/src/components/voice-assistant/ChatbotCTA.tsx
+++ b/src/components/voice-assistant/ChatbotCTA.tsx
@@ -1,0 +1,409 @@
+import { useState, useRef, useEffect, useCallback } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import {
+  Mic, MicOff, Send, Bot, User, MessageCircle,
+  Volume2, VolumeX, Loader2, Sparkles, Zap
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { getFallbackResponse, generateSystemPrompt } from "./danielContext"
+
+interface Message {
+  id: string
+  role: "user" | "assistant"
+  content: string
+  timestamp: Date
+}
+
+// Get Speech Recognition constructor
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getSpeechRecognition(): any {
+  if (typeof window === "undefined") return null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition || null
+}
+
+const speechRecognitionSupported = typeof window !== "undefined" && getSpeechRecognition() !== null
+
+// Fun CTA messages that rotate
+const ctaMessages = [
+  { text: "TL;DR? Just ask my AI.", subtext: "It read everything so you don't have to." },
+  { text: "Too much scrolling?", subtext: "My chatbot has the cliff notes." },
+  { text: "Skip the tour.", subtext: "Ask the robot instead." },
+  { text: "Attention span of a goldfish?", subtext: "Same. That's why I made a chatbot." },
+]
+
+export function ChatbotCTA() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [ctaIndex] = useState(() => Math.floor(Math.random() * ctaMessages.length))
+  const [messages, setMessages] = useState<Message[]>([
+    {
+      id: "welcome",
+      role: "assistant",
+      content: "Hey! I'm Daniel's AI assistant. Ask me anything — skills, projects, random fun facts. I won't judge. 🤖",
+      timestamp: new Date()
+    }
+  ])
+  const [input, setInput] = useState("")
+  const [isListening, setIsListening] = useState(false)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [isSpeaking, setIsSpeaking] = useState(false)
+  const [speechEnabled, setSpeechEnabled] = useState(true)
+
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const recognitionRef = useRef<any>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Scroll to bottom when messages change
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [messages])
+
+  // Initialize speech recognition
+  useEffect(() => {
+    const SpeechRecognitionCtor = getSpeechRecognition()
+    if (SpeechRecognitionCtor) {
+      const recognition = new SpeechRecognitionCtor()
+      recognition.continuous = false
+      recognition.interimResults = false
+      recognition.lang = "en-US"
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      recognition.onresult = (event: any) => {
+        const transcript = event.results[0][0].transcript
+        setInput(transcript)
+        setIsListening(false)
+      }
+
+      recognition.onerror = () => setIsListening(false)
+      recognition.onend = () => setIsListening(false)
+
+      recognitionRef.current = recognition
+    }
+
+    return () => recognitionRef.current?.abort()
+  }, [])
+
+  // Focus input when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 100)
+    }
+  }, [isOpen])
+
+  const toggleListening = useCallback(() => {
+    if (!recognitionRef.current) {
+      alert("Speech recognition is not supported in your browser.")
+      return
+    }
+
+    if (isListening) {
+      recognitionRef.current.stop()
+      setIsListening(false)
+    } else {
+      try {
+        recognitionRef.current.start()
+        setIsListening(true)
+      } catch {
+        setIsListening(false)
+      }
+    }
+  }, [isListening])
+
+  const speakResponse = useCallback((text: string) => {
+    if (!speechEnabled || typeof window === "undefined" || !window.speechSynthesis) return
+
+    window.speechSynthesis.cancel()
+    const utterance = new SpeechSynthesisUtterance(text)
+    utterance.rate = 1.0
+    utterance.pitch = 1.0
+    utterance.volume = 0.8
+
+    utterance.onstart = () => setIsSpeaking(true)
+    utterance.onend = () => setIsSpeaking(false)
+    utterance.onerror = () => setIsSpeaking(false)
+
+    window.speechSynthesis.speak(utterance)
+  }, [speechEnabled])
+
+  const stopSpeaking = useCallback(() => {
+    if (typeof window !== "undefined" && window.speechSynthesis) {
+      window.speechSynthesis.cancel()
+      setIsSpeaking(false)
+    }
+  }, [])
+
+  const sendMessage = useCallback(async () => {
+    const trimmedInput = input.trim()
+    if (!trimmedInput || isProcessing) return
+
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      role: "user",
+      content: trimmedInput,
+      timestamp: new Date()
+    }
+    setMessages(prev => [...prev, userMessage])
+    setInput("")
+    setIsProcessing(true)
+
+    try {
+      let response: string
+
+      const geminiApiKey = import.meta.env.VITE_GEMINI_API_KEY
+      if (geminiApiKey) {
+        try {
+          const apiResponse = await fetch(
+            `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${geminiApiKey}`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                contents: [{
+                  role: "user",
+                  parts: [{ text: generateSystemPrompt() + "\n\nUser question: " + trimmedInput }]
+                }],
+                generationConfig: { maxOutputTokens: 500, temperature: 0.7 }
+              })
+            }
+          )
+
+          if (apiResponse.ok) {
+            const data = await apiResponse.json()
+            response = data.candidates?.[0]?.content?.parts?.[0]?.text || getFallbackResponse(trimmedInput)
+          } else {
+            response = getFallbackResponse(trimmedInput)
+          }
+        } catch {
+          response = getFallbackResponse(trimmedInput)
+        }
+      } else {
+        await new Promise(resolve => setTimeout(resolve, 800))
+        response = getFallbackResponse(trimmedInput)
+      }
+
+      const assistantMessage: Message = {
+        id: (Date.now() + 1).toString(),
+        role: "assistant",
+        content: response,
+        timestamp: new Date()
+      }
+      setMessages(prev => [...prev, assistantMessage])
+      speakResponse(response)
+    } finally {
+      setIsProcessing(false)
+    }
+  }, [input, isProcessing, speakResponse])
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      sendMessage()
+    }
+  }
+
+  const quickQuestions = [
+    "What does Daniel build?",
+    "Top 3 skills?",
+    "Tell me something fun"
+  ]
+
+  const currentCTA = ctaMessages[ctaIndex]
+
+  return (
+    <>
+      {/* CTA Section */}
+      <section className="py-8 relative overflow-hidden">
+        <div className="container">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="relative"
+          >
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 p-6 rounded-2xl bg-gradient-to-r from-primary/5 via-primary/10 to-primary/5 border border-primary/20 backdrop-blur-sm">
+              {/* Icon */}
+              <div className="flex-shrink-0">
+                <motion.div
+                  className="w-14 h-14 rounded-full bg-primary/20 flex items-center justify-center"
+                  animate={{
+                    scale: [1, 1.1, 1],
+                    rotate: [0, 5, -5, 0]
+                  }}
+                  transition={{
+                    duration: 3,
+                    repeat: Infinity,
+                    ease: "easeInOut"
+                  }}
+                >
+                  <Bot className="w-7 h-7 text-primary" />
+                </motion.div>
+              </div>
+
+              {/* Text */}
+              <div className="text-center sm:text-left flex-1">
+                <h3 className="text-lg md:text-xl font-bold text-foreground flex items-center justify-center sm:justify-start gap-2">
+                  {currentCTA.text}
+                  <Zap className="w-4 h-4 text-yellow-500" />
+                </h3>
+                <p className="text-sm text-muted-foreground mt-0.5">
+                  {currentCTA.subtext}
+                </p>
+              </div>
+
+              {/* Button */}
+              <Button
+                onClick={() => setIsOpen(true)}
+                className="flex-shrink-0 gap-2 bg-primary hover:bg-primary/90 shadow-lg shadow-primary/25"
+                size="lg"
+              >
+                <MessageCircle className="w-4 h-4" />
+                Chat Now
+              </Button>
+            </div>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Chat Modal */}
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent className="sm:max-w-[500px] p-0 gap-0 overflow-hidden">
+          <DialogHeader className="p-4 pb-2 border-b bg-gradient-to-r from-primary/10 to-transparent">
+            <DialogTitle className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-full bg-primary/20 flex items-center justify-center">
+                <Sparkles className="w-4 h-4 text-primary" />
+              </div>
+              Ask About Daniel
+            </DialogTitle>
+          </DialogHeader>
+
+          {/* Messages Area */}
+          <div className="h-[350px] overflow-y-auto p-4 space-y-3">
+            <AnimatePresence initial={false}>
+              {messages.map((message) => (
+                <motion.div
+                  key={message.id}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0 }}
+                  className={`flex gap-2 ${message.role === "user" ? "justify-end" : "justify-start"}`}
+                >
+                  {message.role === "assistant" && (
+                    <div className="flex-shrink-0 w-7 h-7 rounded-full bg-primary/20 flex items-center justify-center">
+                      <Bot className="w-3.5 h-3.5 text-primary" />
+                    </div>
+                  )}
+                  <div
+                    className={`max-w-[80%] rounded-2xl px-3 py-2 text-sm ${
+                      message.role === "user"
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-muted"
+                    }`}
+                  >
+                    <p className="whitespace-pre-wrap">{message.content}</p>
+                  </div>
+                  {message.role === "user" && (
+                    <div className="flex-shrink-0 w-7 h-7 rounded-full bg-primary flex items-center justify-center">
+                      <User className="w-3.5 h-3.5 text-primary-foreground" />
+                    </div>
+                  )}
+                </motion.div>
+              ))}
+            </AnimatePresence>
+
+            {isProcessing && (
+              <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="flex gap-2">
+                <div className="flex-shrink-0 w-7 h-7 rounded-full bg-primary/20 flex items-center justify-center">
+                  <Bot className="w-3.5 h-3.5 text-primary" />
+                </div>
+                <div className="bg-muted rounded-2xl px-3 py-2">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                </div>
+              </motion.div>
+            )}
+
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Quick Questions */}
+          {messages.length === 1 && (
+            <div className="px-4 pb-2">
+              <div className="flex flex-wrap gap-1.5">
+                {quickQuestions.map((q) => (
+                  <Button
+                    key={q}
+                    variant="outline"
+                    size="sm"
+                    className="text-xs h-7"
+                    onClick={() => {
+                      setInput(q)
+                      inputRef.current?.focus()
+                    }}
+                  >
+                    {q}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Input Area */}
+          <div className="border-t p-3 bg-muted/30">
+            <div className="flex items-center gap-2">
+              {speechRecognitionSupported && (
+                <Button
+                  variant={isListening ? "default" : "ghost"}
+                  size="icon"
+                  onClick={toggleListening}
+                  disabled={isProcessing}
+                  className={`flex-shrink-0 h-9 w-9 ${isListening ? "bg-red-500 hover:bg-red-600 animate-pulse" : ""}`}
+                >
+                  {isListening ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+                </Button>
+              )}
+
+              <input
+                ref={inputRef}
+                type="text"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={isListening ? "Listening..." : "Ask anything..."}
+                className="flex-1 h-9 px-3 rounded-lg border bg-background text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                disabled={isProcessing || isListening}
+              />
+
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => {
+                  if (isSpeaking) stopSpeaking()
+                  else setSpeechEnabled(!speechEnabled)
+                }}
+                className="flex-shrink-0 h-9 w-9"
+              >
+                {isSpeaking ? (
+                  <Volume2 className="h-4 w-4 animate-pulse text-primary" />
+                ) : speechEnabled ? (
+                  <Volume2 className="h-4 w-4" />
+                ) : (
+                  <VolumeX className="h-4 w-4" />
+                )}
+              </Button>
+
+              <Button
+                onClick={sendMessage}
+                disabled={!input.trim() || isProcessing}
+                size="icon"
+                className="flex-shrink-0 h-9 w-9"
+              >
+                <Send className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/components/voice-assistant/index.ts
+++ b/src/components/voice-assistant/index.ts
@@ -1,2 +1,3 @@
 export { AskAboutMe } from "./AskAboutMe"
+export { ChatbotCTA } from "./ChatbotCTA"
 export { danielContext, generateSystemPrompt, getFallbackResponse } from "./danielContext"


### PR DESCRIPTION
## Summary
Add a fun call-to-action below the Hero section that opens the AI chatbot in a modal.

## CTA Messages (randomly selected)
- "TL;DR? Just ask my AI." / "It read everything so you don't have to."
- "Too much scrolling?" / "My chatbot has the cliff notes."
- "Skip the tour." / "Ask the robot instead."
- "Attention span of a goldfish?" / "Same. That's why I made a chatbot."

## Features
- Animated bot icon
- Modal with full chat functionality
- Quick question buttons for easy start
- Voice input + text-to-speech
- Compact, mobile-friendly design

## Test Plan
- [x] Verify CTA displays below Hero section
- [x] Click "Chat Now" opens modal
- [x] Chat functionality works (typing, sending, voice)
- [x] Modal closes properly