### PR TITLE
Integrate Voice Stocks into ChatbotCTA and fix scroll issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,14 @@ function App() {
   useEffect(() => {
     logConsoleEasterEgg()
 
+    // Disable browser scroll restoration to prevent unwanted scroll on refresh
+    if ('scrollRestoration' in history) {
+      history.scrollRestoration = 'manual'
+    }
+
+    // Force scroll to top on initial load
+    window.scrollTo(0, 0)
+
     // Right-click easter egg
     const handleContextMenu = () => {
       // Don't prevent default - just show the toast briefly

--- a/src/components/providers/SmoothScrollProvider.tsx
+++ b/src/components/providers/SmoothScrollProvider.tsx
@@ -14,6 +14,9 @@ export function SmoothScrollProvider({ children }: { children: React.ReactNode }
       touchMultiplier: 2,
     })
 
+    // Ensure scroll starts at top after Lenis initializes
+    lenisRef.current.scrollTo(0, { immediate: true })
+
     // Animation frame loop
     function raf(time: number) {
       lenisRef.current?.raf(time)

--- a/src/components/providers/SmoothScrollProvider.tsx
+++ b/src/components/providers/SmoothScrollProvider.tsx
@@ -17,13 +17,15 @@ export function SmoothScrollProvider({ children }: { children: React.ReactNode }
     // Ensure scroll starts at top after Lenis initializes
     lenisRef.current.scrollTo(0, { immediate: true })
 
-    // Animation frame loop
+    // Animation frame loop - store ID for cleanup
+    let animationFrameId: number
+
     function raf(time: number) {
       lenisRef.current?.raf(time)
-      requestAnimationFrame(raf)
+      animationFrameId = requestAnimationFrame(raf)
     }
 
-    requestAnimationFrame(raf)
+    animationFrameId = requestAnimationFrame(raf)
 
     // Handle anchor link clicks for smooth scrolling to sections
     const handleAnchorClick = (e: MouseEvent) => {
@@ -47,6 +49,7 @@ export function SmoothScrollProvider({ children }: { children: React.ReactNode }
     document.addEventListener("click", handleAnchorClick)
 
     return () => {
+      cancelAnimationFrame(animationFrameId)
       document.removeEventListener("click", handleAnchorClick)
       lenisRef.current?.destroy()
     }


### PR DESCRIPTION
## Summary
- Integrates the Voice Stocks services into the ChatbotCTA component for navigation and tour functionality
- Fixes the scroll-to-bottom issue that occurred on initial page load

## Changes

### Voice Stocks Integration (ChatbotCTA.tsx)
- Import and connect `processVoiceCommand` from Voice Stocks services
- Route all user input through the voice command router first, falling back to AI if not handled
- Support navigation commands: "go to [section]", "scroll up/down", "find [element]"
- Support tour commands: "give me a tour", "next", "previous", "end tour"
- Support system commands: "help", "clear", "repeat"
- Add tour progress indicator in the modal header
- Add tour control buttons when a tour is active
- Style navigation responses with green accent to distinguish from chat responses
- Connect TTS callbacks so tour voice scripts are spoken
- Update quick questions to include "Give me a tour" and "Go to projects"

### Scroll-to-top Fixes
- **App.tsx**: Disable browser scroll restoration (`history.scrollRestoration = 'manual'`) and force `window.scrollTo(0, 0)` on initial load
- **SmoothScrollProvider.tsx**: Call `lenis.scrollTo(0, { immediate: true })` after initialization to ensure scroll starts at top

## Testing
- [x] Say "give me a tour" - should start guided tour
- [x] Say "go to projects" - should scroll to and highlight projects section
- [x] Say "next" during tour - should advance to next step
- [x] Say "end tour" - should stop the tour
- [x] Refresh the page - should start at top, not bottom
- [x] Navigate away and back - should start at top