### PR TITLE
feat: Improve tour player UX and fix multiple issues

### DIFF
--- a/src/components/voice-assistant/AIAssistant.tsx
+++ b/src/components/voice-assistant/AIAssistant.tsx
@@ -153,9 +153,12 @@ export function AIAssistant() {
       const isActive = guidedTour.getState().isActive
       setTourActive(isActive)
 
-      // Auto-enable Talk Mode when tour starts for hands-free navigation
+      // When tour starts: close the chat modal so content is visible
+      // Auto-enable Talk Mode for hands-free navigation via TourPlayer
       if (isActive && !talkModeRef.current) {
         setTalkMode(true)
+        // Close the chat modal so the tour overlay doesn't block content
+        setIsOpen(false)
       }
     })
 
@@ -515,6 +518,7 @@ If this is NOT a navigation request, respond with ONLY: CHAT` }]
         isSpeaking={isSpeaking}
         onStopSpeaking={stopSpeaking}
         onSpeak={handleTourSpeak}
+        onCancelSpeech={stopSpeaking}
       />
 
       {/* Chat Dialog */}


### PR DESCRIPTION
## Summary

- Auto-close chat modal when tour starts so users can see highlighted content
- Fix z-index so TourPlayer stays above highlight overlays (clickable controls)
- Add dismissable step info panel with close button
- Fix speed menu positioning and change default to 1.5x
- Stop speech immediately when navigating to next/previous step
- Fix tour order by sorting sections by actual DOM position
- Add deduplication to prevent duplicate content types
- Improve section matching using element IDs and data-section attributes
- Rewrite voice scripts to be more engaging and conversational
- Add transition debouncing to prevent erratic jumps

## Test plan

- [x] Start a tour and verify chat modal closes automatically
- [x] Verify TourPlayer controls are clickable during tour
- [x] Test speed menu opens and selections work
- [x] Click next/previous and verify speech stops immediately
- [x] Verify tour progresses in proper top-to-bottom order
- [x] Confirm no duplicate sections appear in tour
- [x] Check voice narration is engaging, not robotic