### PR TITLE
fix: use runtime instead of env for static site

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,7 +1,7 @@
 services:
   - type: web
     name: portfolio-site
-    env: static
+    runtime: static
     buildCommand: npm install && npm run build
     staticPublishPath: ./dist
     envVars:


### PR DESCRIPTION
Fixes Render blueprint sync error by using correct syntax