### PR TITLE
Add environment-based demo mode for admin dashboard

### DIFF
--- a/docs/DEMO_MODE.md
+++ b/docs/DEMO_MODE.md
@@ -1,0 +1,151 @@
+# Demo Mode
+
+This document explains the environment-based demo mode feature for the Portfolio admin dashboard.
+
+## Overview
+
+Demo mode allows visitors to explore the admin dashboard functionality without requiring real authentication. When enabled, users can select from pre-configured demo accounts to experience different access levels.
+
+## Environment Variable
+
+Demo mode is controlled by the `VITE_DEMO_MODE` environment variable:
+
+```bash
+# Enable demo mode
+VITE_DEMO_MODE=true
+
+# Disable demo mode (default)
+VITE_DEMO_MODE=false
+```
+
+## How It Works
+
+### When Demo Mode is Enabled (`VITE_DEMO_MODE=true`)
+
+1. **Login Page**: Instead of showing a traditional login form, the login page displays a demo account selector
+2. **Demo Accounts**: Two pre-configured demo users are available:
+   - **Admin Demo**: Full access to all dashboard features
+   - **Viewer Demo**: Read-only access with restricted features
+3. **Session Persistence**: Demo user selection is stored in sessionStorage for the current browser session
+4. **Clear Indication**: A "Demo Mode" badge is visible throughout the admin dashboard
+
+### When Demo Mode is Disabled (`VITE_DEMO_MODE=false`)
+
+1. **Login Page**: Shows a standard email/password login form
+2. **Real Authentication**: Integrates with your authentication provider (Firebase, Auth0, etc.)
+3. **Protected Routes**: Admin routes require actual authentication
+
+## Architecture
+
+### Files
+
+- `/src/context/auth-context.tsx` - Authentication context with demo mode support
+- `/src/pages/Login.tsx` - Login page with demo/real auth switching
+- `/src/pages/Admin.tsx` - Admin dashboard
+- `/src/components/auth/ProtectedRoute.tsx` - Route protection component
+
+### Demo Users
+
+```typescript
+const DEMO_USERS = [
+  {
+    id: 'demo-admin',
+    name: 'Admin Demo',
+    email: 'admin@demo.com',
+    role: 'admin',
+  },
+  {
+    id: 'demo-viewer',
+    name: 'Viewer Demo',
+    email: 'viewer@demo.com',
+    role: 'viewer',
+  },
+]
+```
+
+## Routes
+
+| Route | Description | Auth Required |
+|-------|-------------|---------------|
+| `/login` | Login/demo selector page | No |
+| `/admin` | Admin dashboard | Yes |
+| `/` | Public portfolio (unchanged) | No |
+
+## Usage
+
+### Local Development
+
+Create a `.env.local` file:
+
+```bash
+VITE_DEMO_MODE=true
+```
+
+### Production (Render)
+
+The `render.yaml` is configured to enable demo mode by default:
+
+```yaml
+envVars:
+  - key: VITE_DEMO_MODE
+    value: "true"
+```
+
+To disable demo mode in production, update the environment variable in the Render dashboard or modify `render.yaml`:
+
+```yaml
+envVars:
+  - key: VITE_DEMO_MODE
+    value: "false"
+```
+
+## Security Considerations
+
+1. **Demo mode is for showcasing only**: No real data is modified
+2. **Session-based**: Demo sessions are not persisted across browser restarts
+3. **Clear visual indicators**: Users always know they're in demo mode
+4. **No sensitive operations**: Demo accounts cannot perform destructive actions
+
+## Extending Demo Mode
+
+### Adding New Demo Users
+
+Edit `/src/context/auth-context.tsx`:
+
+```typescript
+const DEMO_USERS = [
+  // ... existing users
+  {
+    id: 'demo-editor',
+    name: 'Editor Demo',
+    email: 'editor@demo.com',
+    role: 'editor',
+  },
+]
+```
+
+### Adding Role Checks
+
+Use the `useAuth` hook in components:
+
+```typescript
+import { useAuth } from '@/context/auth-context'
+
+function MyComponent() {
+  const { user, isDemoMode } = useAuth()
+
+  if (user?.role !== 'admin') {
+    return <p>Admin access required</p>
+  }
+
+  return <AdminFeature />
+}
+```
+
+## Testing
+
+1. Set `VITE_DEMO_MODE=true` in your environment
+2. Navigate to `/login`
+3. Select a demo account
+4. Explore the admin dashboard
+5. Verify role-based access restrictions work correctly

--- a/env.sample
+++ b/env.sample
@@ -2,3 +2,8 @@
 # Get your free token at: https://cesium.com/ion/tokens
 # This is required for the 3D globe feature to work without warnings
 VITE_CESIUM_ION_TOKEN=your_cesium_ion_token_here
+
+# Demo Mode
+# When set to "true", the admin login page shows demo account selector
+# instead of real authentication. Useful for showcasing the admin dashboard.
+VITE_DEMO_MODE=true

--- a/render.yaml
+++ b/render.yaml
@@ -7,6 +7,8 @@ services:
     envVars:
       - key: VITE_CESIUM_ION_TOKEN
         sync: false
+      - key: VITE_DEMO_MODE
+        value: "true"
     headers:
       - path: /*
         name: Cache-Control

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "@/components/providers/ThemeProvider"
 import { GamificationProvider } from "@/components/providers/GamificationProvider"
 import { SmoothScrollProvider } from "@/components/providers/SmoothScrollProvider"
 import { BossProvider } from "@/context/boss-context"
+import { AuthProvider } from "@/context/auth-context"
 import { CreatureLayer } from "@/components/game/CreatureLayer"
 import { CustomCursor } from "@/components/ui/CustomCursor"
 import { ScrollToTop } from "@/components/shared/ScrollToTop"
@@ -64,12 +65,13 @@ function App() {
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
       <GamificationProvider>
         <BossProvider>
-          <BrowserRouter>
-            <ScrollToTop />
-            <SmoothScrollProvider>
-              <CustomCursor />
-              <CreatureLayer />
-              <AppRoutes />
+          <AuthProvider>
+            <BrowserRouter>
+              <ScrollToTop />
+              <SmoothScrollProvider>
+                <CustomCursor />
+                <CreatureLayer />
+                <AppRoutes />
 
               {/* Right-click easter egg toast */}
               <AnimatePresence>
@@ -80,12 +82,13 @@ function App() {
                     exit={{ opacity: 0, y: -20 }}
                     className="fixed bottom-8 left-1/2 -translate-x-1/2 z-[100] bg-background/95 backdrop-blur-md px-6 py-3 rounded-lg border border-primary/50 shadow-lg pointer-events-none"
                   >
-                    <p className="text-sm text-foreground">Inspecting my work? I respect that. 🔍</p>
+                    <p className="text-sm text-foreground">Inspecting my work? I respect that.</p>
                   </motion.div>
                 )}
               </AnimatePresence>
-            </SmoothScrollProvider>
-          </BrowserRouter>
+              </SmoothScrollProvider>
+            </BrowserRouter>
+          </AuthProvider>
         </BossProvider>
       </GamificationProvider>
     </ThemeProvider>

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -24,6 +24,9 @@ import { Social } from "@/pages/Social"
 import { Games } from "@/pages/Games"
 import { ProjectsPage } from "@/pages/ProjectsPage"
 import { NotFound } from "@/pages/NotFound"
+import { Login } from "@/pages/Login"
+import { Admin } from "@/pages/Admin"
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute"
 
 const Home = () => (
     <div className="min-h-screen">
@@ -59,6 +62,17 @@ export function AppRoutes() {
         <Route path="/agar" element={<AgarGame />} />
         <Route path="*" element={<NotFound />} />
       </Route>
+
+      {/* Auth routes - outside RootLayout for clean login/admin experience */}
+      <Route path="/login" element={<Login />} />
+      <Route
+        path="/admin"
+        element={
+          <ProtectedRoute>
+            <Admin />
+          </ProtectedRoute>
+        }
+      />
     </Routes>
   )
 }

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from 'react-router-dom'
+import { useAuth, type UserRole } from '@/context/auth-context'
+
+interface ProtectedRouteProps {
+  children: React.ReactNode
+  requiredRole?: UserRole
+}
+
+export function ProtectedRoute({ children, requiredRole }: ProtectedRouteProps) {
+  const { isAuthenticated, user } = useAuth()
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />
+  }
+
+  if (requiredRole && user?.role !== requiredRole) {
+    // User is authenticated but doesn't have the required role
+    return <Navigate to="/admin" replace />
+  }
+
+  return <>{children}</>
+}

--- a/src/context/auth-context.tsx
+++ b/src/context/auth-context.tsx
@@ -1,0 +1,126 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
+
+// Demo users for showcasing the admin dashboard
+const DEMO_USERS = [
+  {
+    id: 'demo-admin',
+    name: 'Admin Demo',
+    email: 'admin@demo.com',
+    role: 'admin' as const,
+    avatar: '/avatars/admin.png',
+  },
+  {
+    id: 'demo-viewer',
+    name: 'Viewer Demo',
+    email: 'viewer@demo.com',
+    role: 'viewer' as const,
+    avatar: '/avatars/viewer.png',
+  },
+]
+
+export type UserRole = 'admin' | 'viewer'
+
+export interface User {
+  id: string
+  name: string
+  email: string
+  role: UserRole
+  avatar?: string
+}
+
+interface AuthContextType {
+  user: User | null
+  isAuthenticated: boolean
+  isDemoMode: boolean
+  demoUsers: typeof DEMO_USERS
+  login: (email: string, password: string) => Promise<boolean>
+  loginAsDemo: (userId: string) => void
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextType | null>(null)
+
+// Check if demo mode is enabled via environment variable
+const isDemoModeEnabled = (): boolean => {
+  return import.meta.env.VITE_DEMO_MODE === 'true'
+}
+
+interface AuthProviderProps {
+  children: ReactNode
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [user, setUser] = useState<User | null>(null)
+  const isDemoMode = isDemoModeEnabled()
+
+  const login = useCallback(async (email: string, password: string): Promise<boolean> => {
+    // In demo mode, we don't use real authentication
+    if (isDemoMode) {
+      console.warn('Demo mode enabled - use demo login instead')
+      return false
+    }
+
+    // TODO: Implement real authentication
+    // This would integrate with your auth provider (Firebase, Auth0, etc.)
+    console.log('Real auth login attempt:', email, password)
+    return false
+  }, [isDemoMode])
+
+  const loginAsDemo = useCallback((userId: string) => {
+    if (!isDemoMode) {
+      console.warn('Demo login only available in demo mode')
+      return
+    }
+
+    const demoUser = DEMO_USERS.find(u => u.id === userId)
+    if (demoUser) {
+      setUser(demoUser)
+      // Store in session for persistence during page refresh
+      sessionStorage.setItem('demo-user', JSON.stringify(demoUser))
+    }
+  }, [isDemoMode])
+
+  const logout = useCallback(() => {
+    setUser(null)
+    sessionStorage.removeItem('demo-user')
+  }, [])
+
+  // Restore demo user from session on mount
+  useState(() => {
+    if (isDemoMode) {
+      const stored = sessionStorage.getItem('demo-user')
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored) as User
+          setUser(parsed)
+        } catch {
+          sessionStorage.removeItem('demo-user')
+        }
+      }
+    }
+  })
+
+  const value: AuthContextType = {
+    user,
+    isAuthenticated: user !== null,
+    isDemoMode,
+    demoUsers: DEMO_USERS,
+    login,
+    loginAsDemo,
+    logout,
+  }
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth(): AuthContextType {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,0 +1,205 @@
+import { motion } from 'framer-motion'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '@/context/auth-context'
+import { Button } from '@/components/ui/button'
+import {
+  LogOut,
+  User,
+  Shield,
+  FileText,
+  Settings,
+  BarChart3,
+  MessageSquare,
+  Image,
+  Code2,
+} from 'lucide-react'
+
+const adminFeatures = [
+  {
+    icon: FileText,
+    title: 'Blog Posts',
+    description: 'Manage and publish blog articles',
+    adminOnly: false,
+  },
+  {
+    icon: Code2,
+    title: 'Projects',
+    description: 'Update portfolio projects',
+    adminOnly: false,
+  },
+  {
+    icon: Image,
+    title: 'Media Library',
+    description: 'Upload and manage images',
+    adminOnly: false,
+  },
+  {
+    icon: MessageSquare,
+    title: 'Messages',
+    description: 'View contact form submissions',
+    adminOnly: false,
+  },
+  {
+    icon: BarChart3,
+    title: 'Analytics',
+    description: 'View site traffic and engagement',
+    adminOnly: true,
+  },
+  {
+    icon: Settings,
+    title: 'Settings',
+    description: 'Configure site settings',
+    adminOnly: true,
+  },
+]
+
+export function Admin() {
+  const { user, logout, isDemoMode } = useAuth()
+  const navigate = useNavigate()
+
+  const handleLogout = () => {
+    logout()
+    navigate('/login')
+  }
+
+  const isAdmin = user?.role === 'admin'
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header */}
+      <header className="sticky top-0 z-50 border-b border-border bg-background/95 backdrop-blur">
+        <div className="container flex h-16 items-center justify-between">
+          <div className="flex items-center gap-4">
+            <h1 className="text-xl font-bold">Admin Dashboard</h1>
+            {isDemoMode && (
+              <span className="px-2 py-1 text-xs font-medium bg-amber-500/10 text-amber-500 rounded-full">
+                Demo Mode
+              </span>
+            )}
+          </div>
+
+          <div className="flex items-center gap-4">
+            {/* User Info */}
+            <div className="flex items-center gap-3">
+              <div className={`p-2 rounded-full ${
+                isAdmin
+                  ? 'bg-cyan-500/10 text-cyan-500'
+                  : 'bg-purple-500/10 text-purple-500'
+              }`}>
+                {isAdmin ? <Shield className="h-4 w-4" /> : <User className="h-4 w-4" />}
+              </div>
+              <div className="hidden sm:block">
+                <p className="text-sm font-medium">{user?.name}</p>
+                <p className="text-xs text-muted-foreground capitalize">{user?.role}</p>
+              </div>
+            </div>
+
+            <Button variant="outline" size="sm" onClick={handleLogout}>
+              <LogOut className="h-4 w-4 mr-2" />
+              Logout
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <main className="container py-8">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mb-8"
+        >
+          <h2 className="text-2xl font-bold mb-2">
+            Welcome back, {user?.name?.split(' ')[0]}!
+          </h2>
+          <p className="text-muted-foreground">
+            {isDemoMode
+              ? 'This is a demo of the admin dashboard. Explore the features below.'
+              : 'Manage your portfolio content and settings.'}
+          </p>
+        </motion.div>
+
+        {/* Feature Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {adminFeatures.map((feature, index) => {
+            const isDisabled = feature.adminOnly && !isAdmin
+            const Icon = feature.icon
+
+            return (
+              <motion.div
+                key={feature.title}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: index * 0.1 }}
+              >
+                <button
+                  disabled={isDisabled}
+                  className={`w-full p-6 text-left rounded-lg border transition-all ${
+                    isDisabled
+                      ? 'border-border bg-muted/50 opacity-50 cursor-not-allowed'
+                      : 'border-border bg-card hover:border-primary/50 hover:bg-accent/50 cursor-pointer'
+                  }`}
+                >
+                  <div className="flex items-start gap-4">
+                    <div className={`p-3 rounded-lg ${
+                      isDisabled
+                        ? 'bg-muted text-muted-foreground'
+                        : 'bg-primary/10 text-primary'
+                    }`}>
+                      <Icon className="h-6 w-6" />
+                    </div>
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2">
+                        <h3 className="font-semibold">{feature.title}</h3>
+                        {feature.adminOnly && (
+                          <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                            Admin Only
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-sm text-muted-foreground mt-1">
+                        {feature.description}
+                      </p>
+                      {isDisabled && (
+                        <p className="text-xs text-amber-500 mt-2">
+                          Requires admin access
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </button>
+              </motion.div>
+            )
+          })}
+        </div>
+
+        {/* Demo Mode Info */}
+        {isDemoMode && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.5 }}
+            className="mt-8 p-6 bg-gradient-to-r from-primary/5 to-secondary/5 border border-primary/20 rounded-lg"
+          >
+            <h3 className="font-semibold mb-2">About Demo Mode</h3>
+            <p className="text-sm text-muted-foreground mb-4">
+              You're viewing a demonstration of the admin dashboard. In a production environment,
+              this would connect to a real backend with actual content management capabilities.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <span className="text-xs px-3 py-1 bg-background rounded-full border">
+                No data is saved
+              </span>
+              <span className="text-xs px-3 py-1 bg-background rounded-full border">
+                Safe to explore
+              </span>
+              <span className="text-xs px-3 py-1 bg-background rounded-full border">
+                Role-based access demo
+              </span>
+            </div>
+          </motion.div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,189 @@
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '@/context/auth-context'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { User, Shield, Eye, LogIn } from 'lucide-react'
+
+export function Login() {
+  const { isDemoMode, demoUsers, loginAsDemo, login, isAuthenticated } = useAuth()
+  const navigate = useNavigate()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Redirect if already authenticated
+  if (isAuthenticated) {
+    navigate('/admin')
+    return null
+  }
+
+  const handleDemoLogin = (userId: string) => {
+    loginAsDemo(userId)
+    navigate('/admin')
+  }
+
+  const handleRealLogin = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setIsLoading(true)
+
+    try {
+      const success = await login(email, password)
+      if (success) {
+        navigate('/admin')
+      } else {
+        setError('Invalid credentials')
+      }
+    } catch {
+      setError('Login failed. Please try again.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // Demo mode: Show demo user selector
+  if (isDemoMode) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="w-full max-w-md"
+        >
+          {/* Demo Mode Banner */}
+          <div className="mb-6 p-4 bg-gradient-to-r from-amber-500/10 to-orange-500/10 border border-amber-500/30 rounded-lg">
+            <div className="flex items-center gap-2 text-amber-500 mb-2">
+              <Eye className="h-5 w-5" />
+              <span className="font-semibold">Demo Mode</span>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Select a demo account to explore the admin dashboard. No real authentication required.
+            </p>
+          </div>
+
+          {/* Demo User Cards */}
+          <div className="space-y-4">
+            <h2 className="text-2xl font-bold text-center mb-6">Choose a Demo Account</h2>
+
+            {demoUsers.map((demoUser) => (
+              <motion.button
+                key={demoUser.id}
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+                onClick={() => handleDemoLogin(demoUser.id)}
+                className="w-full p-4 bg-card border border-border rounded-lg hover:border-primary/50 hover:bg-accent/50 transition-all text-left group"
+              >
+                <div className="flex items-center gap-4">
+                  <div className={`p-3 rounded-full ${
+                    demoUser.role === 'admin'
+                      ? 'bg-gradient-to-r from-cyan-500/20 to-blue-500/20 text-cyan-500'
+                      : 'bg-gradient-to-r from-purple-500/20 to-pink-500/20 text-purple-500'
+                  }`}>
+                    {demoUser.role === 'admin' ? (
+                      <Shield className="h-6 w-6" />
+                    ) : (
+                      <User className="h-6 w-6" />
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="font-semibold text-foreground group-hover:text-primary transition-colors">
+                      {demoUser.name}
+                    </h3>
+                    <p className="text-sm text-muted-foreground">{demoUser.email}</p>
+                    <span className={`inline-block mt-1 text-xs px-2 py-0.5 rounded-full ${
+                      demoUser.role === 'admin'
+                        ? 'bg-cyan-500/10 text-cyan-500'
+                        : 'bg-purple-500/10 text-purple-500'
+                    }`}>
+                      {demoUser.role === 'admin' ? 'Full Access' : 'Read Only'}
+                    </span>
+                  </div>
+                  <LogIn className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
+                </div>
+              </motion.button>
+            ))}
+          </div>
+
+          {/* Back to Portfolio Link */}
+          <div className="mt-8 text-center">
+            <Button
+              variant="ghost"
+              onClick={() => navigate('/')}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              Back to Portfolio
+            </Button>
+          </div>
+        </motion.div>
+      </div>
+    )
+  }
+
+  // Real authentication form (when not in demo mode)
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="w-full max-w-md"
+      >
+        <div className="bg-card border border-border rounded-lg p-8">
+          <h2 className="text-2xl font-bold text-center mb-6">Admin Login</h2>
+
+          <form onSubmit={handleRealLogin} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="admin@example.com"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Enter your password"
+                required
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={isLoading}
+            >
+              {isLoading ? 'Signing in...' : 'Sign In'}
+            </Button>
+          </form>
+        </div>
+
+        {/* Back to Portfolio Link */}
+        <div className="mt-6 text-center">
+          <Button
+            variant="ghost"
+            onClick={() => navigate('/')}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            Back to Portfolio
+          </Button>
+        </div>
+      </motion.div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add demo mode feature controlled by `VITE_DEMO_MODE` environment variable
- When enabled, the login page (`/login`) shows a demo account selector instead of real authentication
- Users can explore the admin dashboard (`/admin`) with different role levels (Admin/Viewer)
- Marketing pages and portfolio content remain unchanged

## Changes

- **Auth Context** (`src/context/auth-context.tsx`): Manages demo mode detection, demo users, and auth state
- **Login Page** (`src/pages/Login.tsx`): Shows demo selector when demo mode enabled, real auth form otherwise
- **Admin Dashboard** (`src/pages/Admin.tsx`): Dashboard with role-based feature access
- **Protected Route** (`src/components/auth/ProtectedRoute.tsx`): Route guard for authenticated pages
- **render.yaml**: Adds `VITE_DEMO_MODE=true` for production demo mode
- **Documentation** (`docs/DEMO_MODE.md`): Comprehensive documentation for the feature

## Test plan

- [ ] Set `VITE_DEMO_MODE=true` in local `.env`
- [ ] Navigate to `/login` and verify demo account selector appears
- [ ] Login as Admin Demo and verify full dashboard access
- [ ] Login as Viewer Demo and verify restricted access (admin-only features disabled)
- [ ] Set `VITE_DEMO_MODE=false` and verify real login form appears
- [ ] Verify `/admin` redirects to `/login` when not authenticated
- [ ] Verify marketing pages (home, projects, etc.) remain unchanged