### PR TITLE
fix: sync react-dom version with react

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lenis": "^1.3.17",
     "lucide-react": "^0.563.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.0",
+    "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.0",
     "react-joystick-component": "^6.2.1",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## Summary
Syncs react-dom version (19.2.4) with react version to fix runtime error #527.

## Problem
```
Uncaught Error: Minified React error #527
if (vP !== "19.2.3") throw Error(i(527, vP, "19.2.3"))
```

React 19.2.4 was loaded but react-dom expected 19.2.3.

## Test plan
- [ ] Verify site loads without version mismatch error