### PR TITLE
fix: AI assistant voice bugs and game improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lenis": "^1.3.17",
     "lucide-react": "^0.563.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.0",
+    "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.0",
     "react-joystick-component": "^6.2.1",
     "react-markdown": "^10.1.0",

--- a/src/components/game/agar/index.tsx
+++ b/src/components/game/agar/index.tsx
@@ -72,7 +72,6 @@ export function AgarGame() {
   const [highScore, setHighScore] = useState(() =>
     parseInt(localStorage.getItem("agar-highscore") || "0", 10)
   )
-  const [isNewHighScore, setIsNewHighScore] = useState(false)
   const [leaderboard, setLeaderboard] = useState<{ name: string; score: number; isPlayer?: boolean; isPlayer2?: boolean }[]>([])
 
   // Initialize food

--- a/src/components/game/agar/index.tsx
+++ b/src/components/game/agar/index.tsx
@@ -70,8 +70,9 @@ export function AgarGame() {
   const [score, setScore] = useState(0)
   const [score2, setScore2] = useState(0) // Player 2 score
   const [highScore, setHighScore] = useState(() =>
-    parseInt(localStorage.getItem("agar-highscore") || "0")
+    parseInt(localStorage.getItem("agar-highscore") || "0", 10)
   )
+  const [isNewHighScore, setIsNewHighScore] = useState(false)
   const [leaderboard, setLeaderboard] = useState<{ name: string; score: number; isPlayer?: boolean; isPlayer2?: boolean }[]>([])
 
   // Initialize food

--- a/src/components/voice-assistant/AskAboutMe.tsx
+++ b/src/components/voice-assistant/AskAboutMe.tsx
@@ -387,7 +387,15 @@ export function AskAboutMe() {
                   <textarea
                     ref={inputRef}
                     value={displayText}
-                    onChange={(e) => setInput(e.target.value)}
+                    onChange={(e) => {
+                      const value = e.target.value
+                      if (interimTranscript && value.endsWith(interimTranscript)) {
+                        const trimmed = value.slice(0, -interimTranscript.length)
+                        setInput(trimmed.endsWith(" ") ? trimmed.slice(0, -1) : trimmed)
+                      } else {
+                        setInput(value)
+                      }
+                    }}
                     onKeyDown={handleKeyDown}
                     placeholder={isListening ? "Listening... speak now" : "Ask me anything about Daniel..."}
                     className="flex-1 min-h-[44px] max-h-[120px] px-4 py-2 rounded-xl border bg-background resize-none focus:outline-none focus:ring-2 focus:ring-primary/50"

--- a/src/services/voice-stocks/voiceCommandRouter.ts
+++ b/src/services/voice-stocks/voiceCommandRouter.ts
@@ -315,6 +315,7 @@ Or just ask me anything about Daniel!`;
     }
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('assistant-stop-speech'));
+      window.dispatchEvent(new CustomEvent('assistant-stop-listening'));
     }
     return { handled: true, shouldSpeak: false };
   }


### PR DESCRIPTION
## Summary
- Add `assistant-stop-listening` event handler to properly reset talk mode and stop recognition
- Check `isListeningRef.current` before restarting listening after speech ends to prevent duplicate listeners
- Handle interim transcript in input field `onChange` to prevent text duplication when editing
- Fix agar game `parseInt` to include radix parameter (10) for consistent behavior
- Remove unused `isNewHighScore` state from agar game

## Test plan
- [x] Test "stop" voice command properly stops listening and resets talk mode
- [x] Test that listening does not restart multiple times after assistant finishes speaking
- [x] Test editing text in voice assistant input field while interim transcript is displayed
- [x] Test agar game high score persistence across sessions