### PR TITLE
Fix TypeScript error: move stopListening before usage

### DIFF
--- a/src/components/voice-assistant/AIAssistant.tsx
+++ b/src/components/voice-assistant/AIAssistant.tsx
@@ -131,6 +131,14 @@ export function AIAssistant() {
     isListeningRef.current = isListening
   }, [isListening])
 
+  // Stop listening - defined early since it's used in event handlers below
+  const stopListening = useCallback(() => {
+    if (recognitionRef.current) {
+      try { recognitionRef.current.stop() } catch { /* ignore */ }
+    }
+    setIsListening(false)
+    setInterimTranscript("")
+  }, [])
 
   // Scroll to bottom when messages change
   useEffect(() => {
@@ -327,14 +335,6 @@ export function AIAssistant() {
         setTimeout(() => setSpeechError(null), 4000)
       }
     }, 150)
-  }, [])
-
-  const stopListening = useCallback(() => {
-    if (recognitionRef.current) {
-      try { recognitionRef.current.stop() } catch { /* ignore */ }
-    }
-    setIsListening(false)
-    setInterimTranscript("")
   }, [])
 
   const toggleListening = useCallback(() => {


### PR DESCRIPTION
## Summary
- Fix TypeScript TS2448 error where `stopListening` callback was used before its declaration
- Move the `stopListening` useCallback definition above the useEffect that references it

## Test plan
- [ ] Verify TypeScript compiles without errors
- [ ] Verify Render build succeeds