### PR TITLE
Add techie mode with IDE-style terminal interface

### DIFF
--- a/src/components/techie/AboutDialog.tsx
+++ b/src/components/techie/AboutDialog.tsx
@@ -1,0 +1,46 @@
+interface AboutDialogProps {
+  onClose: () => void
+}
+
+export function AboutDialog({ onClose }: AboutDialogProps) {
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="bg-[#f0f0f0] text-[#333] border border-[#999] shadow-xl w-[360px] font-sans"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Title bar */}
+        <div className="flex items-center justify-between px-3 py-1.5 bg-gradient-to-b from-[#e8e8e8] to-[#d0d0d0] border-b border-[#999]">
+          <span className="text-xs font-semibold">About DH OS</span>
+          <button
+            onClick={onClose}
+            className="w-4 h-4 flex items-center justify-center text-[#666] hover:text-[#000] text-lg leading-none"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex flex-col items-center py-8 px-6">
+          <div className="text-4xl mb-4">&#x2699;&#xFE0F;</div>
+          <h2 className="text-lg font-bold mb-1">DH OS v1.0.0</h2>
+          <p className="text-sm text-[#555] mb-1">Built with React, TypeScript, & Tailwind.</p>
+          <p className="text-sm text-[#555] mb-6 italic">Runs on caffeine and curiosity.</p>
+
+          <div className="text-xs text-[#888] mb-6 text-center space-y-0.5">
+            <p>28+ projects shipped</p>
+            <p>6+ years engineering</p>
+            <p>16 easter eggs hidden</p>
+          </div>
+
+          <button
+            onClick={onClose}
+            className="px-8 py-1.5 bg-[#e74c3c] hover:bg-[#c0392b] text-white text-sm font-semibold rounded transition-colors"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/techie/MatrixRain.tsx
+++ b/src/components/techie/MatrixRain.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useCallback } from "react"
+
+interface MatrixRainProps {
+  onDismiss: () => void
+}
+
+export function MatrixRain({ onDismiss }: MatrixRainProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const animationRef = useRef<number>(0)
+
+  const animate = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    canvas.width = window.innerWidth
+    canvas.height = window.innerHeight
+
+    const fontSize = 14
+    const columns = Math.floor(canvas.width / fontSize)
+    const drops: number[] = Array(columns).fill(1)
+
+    // Characters: mix of katakana, latin, digits, and symbols
+    const chars = "abcdefghijklmnopqrstuvwxyz0123456789@#$%^&*(){}[]|;:<>?/~"
+
+    const draw = () => {
+      ctx.fillStyle = "rgba(0, 0, 0, 0.05)"
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+      ctx.fillStyle = "#0f0"
+      ctx.font = `${fontSize}px monospace`
+
+      for (let i = 0; i < drops.length; i++) {
+        const char = chars[Math.floor(Math.random() * chars.length)]
+
+        // Leading character is brighter
+        const y = drops[i] * fontSize
+        if (y > 0 && y < canvas.height) {
+          ctx.fillStyle = "#fff"
+          ctx.fillText(char, i * fontSize, y)
+          ctx.fillStyle = "#0f0"
+          if (y - fontSize > 0) {
+            const prevChar = chars[Math.floor(Math.random() * chars.length)]
+            ctx.fillText(prevChar, i * fontSize, y - fontSize)
+          }
+        }
+
+        if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) {
+          drops[i] = 0
+        }
+        drops[i]++
+      }
+
+      animationRef.current = requestAnimationFrame(draw)
+    }
+
+    draw()
+  }, [])
+
+  useEffect(() => {
+    animate()
+
+    const handleResize = () => {
+      const canvas = canvasRef.current
+      if (canvas) {
+        canvas.width = window.innerWidth
+        canvas.height = window.innerHeight
+      }
+    }
+
+    window.addEventListener("resize", handleResize)
+    return () => {
+      cancelAnimationFrame(animationRef.current)
+      window.removeEventListener("resize", handleResize)
+    }
+  }, [animate])
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] cursor-pointer"
+      onClick={onDismiss}
+      onKeyDown={onDismiss}
+      role="button"
+      tabIndex={0}
+    >
+      <canvas ref={canvasRef} className="w-full h-full bg-black" />
+      <div className="absolute bottom-8 left-1/2 -translate-x-1/2 text-green-400 text-sm font-mono animate-pulse">
+        Click anywhere to escape the matrix...
+      </div>
+    </div>
+  )
+}

--- a/src/components/techie/TechieContentViewer.tsx
+++ b/src/components/techie/TechieContentViewer.tsx
@@ -1,0 +1,339 @@
+import { lazy, Suspense, useRef, useEffect } from "react"
+import { experienceData } from "@/data/experience"
+import { skillsData } from "@/data/skills"
+import { projectsData } from "@/data/projects"
+import { blogPosts } from "@/data/blog"
+import type { TechieTab } from "./TechieLayout"
+
+const SnakeGame = lazy(() => import("@/components/game/SnakeGame").then(m => ({ default: m.SnakeGame })))
+const TetrisGame = lazy(() => import("@/components/game/TetrisGame").then(m => ({ default: m.TetrisGame })))
+const ChessGame = lazy(() => import("@/components/game/ChessGame").then(m => ({ default: m.ChessGame })))
+const FallingBlocksGame = lazy(() => import("@/components/game/FallingBlocksGame").then(m => ({ default: m.FallingBlocksGame })))
+const CookieClickerGame = lazy(() => import("@/components/game/cookie-clicker").then(m => ({ default: m.CookieClickerGame })))
+const AgarGame = lazy(() => import("@/components/game/agar").then(m => ({ default: m.AgarGame })))
+
+interface TechieContentViewerProps {
+  tab: TechieTab | null
+  onEditorChange: (tabId: string, content: string) => void
+}
+
+function TerminalLine({ prefix, children }: { prefix?: string; children: React.ReactNode }) {
+  return (
+    <div className="flex gap-2">
+      {prefix && <span className="text-[#569cd6] shrink-0">{prefix}</span>}
+      <span>{children}</span>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-6">
+      <div className="text-[#569cd6] font-bold mb-2 border-b border-[#3c3c3c] pb-1">{title}</div>
+      {children}
+    </div>
+  )
+}
+
+function ReadmeContent() {
+  return (
+    <div className="space-y-4">
+      <div className="text-[#608b4e]">{`# Daniel Hernandez`}</div>
+      <div className="text-[#608b4e]">{`## Senior Software Engineer`}</div>
+      <div className="text-[#ce9178] mt-4">
+        Full-stack engineer with 6+ years building production-grade applications.
+        From co-founding a software consultancy to developing secure DoD applications
+        for Space Force and Navy.
+      </div>
+      <div className="mt-4 space-y-1">
+        <TerminalLine prefix=">">{`React | Next.js | TypeScript | Node.js | Python | Django`}</TerminalLine>
+        <TerminalLine prefix=">">{`AWS | Docker | Kubernetes | PostgreSQL | MongoDB`}</TerminalLine>
+        <TerminalLine prefix=">">{`Three.js | Cesium | Framer Motion | GSAP`}</TerminalLine>
+      </div>
+      <div className="mt-6 text-[#608b4e]">{`## Quick Start`}</div>
+      <div className="bg-[#1a1a1a] p-3 rounded text-[#d4d4d4] text-xs space-y-1">
+        <div><span className="text-[#569cd6]">$</span> open ABOUT.md        <span className="text-[#608b4e]"># Learn about me</span></div>
+        <div><span className="text-[#569cd6]">$</span> cat SKILLS.txt       <span className="text-[#608b4e]"># View my skills</span></div>
+        <div><span className="text-[#569cd6]">$</span> less EXPERIENCE.log  <span className="text-[#608b4e]"># Career history</span></div>
+        <div><span className="text-[#569cd6]">$</span> ls PROJECTS/         <span className="text-[#608b4e]"># Browse projects</span></div>
+        <div><span className="text-[#569cd6]">$</span> ./GAMES/snake.exe    <span className="text-[#608b4e]"># Play a game</span></div>
+      </div>
+    </div>
+  )
+}
+
+function AboutContent() {
+  return (
+    <div className="space-y-4">
+      <div className="text-[#608b4e]">{`# About Me`}</div>
+      <div className="text-[#ce9178]">
+        I'm a self-taught engineer who went from a GED to building DoD applications
+        for Space Force. I co-founded a software consultancy, built 28+ projects,
+        and never stopped learning.
+      </div>
+      <div className="mt-4 text-[#ce9178]">
+        Beyond code, I weld (MIG, TIG, stick), solder PCBs, run a 3D print farm,
+        build VR games, and design CAD prototypes. I believe the best engineers
+        are the ones who build things with their hands.
+      </div>
+      <Section title="Timeline">
+        <div className="space-y-1 text-sm">
+          <TerminalLine prefix="2015">{`Started learning to code (PHP, HTML/CSS)`}</TerminalLine>
+          <TerminalLine prefix="2017">{`Teaching Assistant at Lake Land College`}</TerminalLine>
+          <TerminalLine prefix="2018">{`Freelance web development (Brainy Developer)`}</TerminalLine>
+          <TerminalLine prefix="2020">{`Full-Stack Engineer at Charter Communications`}</TerminalLine>
+          <TerminalLine prefix="2021">{`Co-founded Tailored Technologies`}</TerminalLine>
+          <TerminalLine prefix="2022">{`Senior Engineer at First American`}</TerminalLine>
+          <TerminalLine prefix="2023">{`Senior Engineer at Mesirow Financial`}</TerminalLine>
+          <TerminalLine prefix="2024">{`Senior Engineer at BrainGu (DoD)`}</TerminalLine>
+        </div>
+      </Section>
+    </div>
+  )
+}
+
+function SkillsContent() {
+  const categories = [...new Set(skillsData.map(s => s.category))]
+  return (
+    <div className="space-y-4">
+      <div className="text-[#608b4e]">{`# Skills`}</div>
+      {categories.map(cat => {
+        const skills = skillsData.filter(s => s.category === cat)
+        return (
+          <Section key={cat} title={cat}>
+            <div className="space-y-1 text-sm">
+              {skills.map(s => (
+                <div key={s.name} className="flex items-center gap-3">
+                  <span className="text-[#4ec9b0] w-24 shrink-0">{s.name}</span>
+                  <span className="text-[#858585] w-20 shrink-0">{s.level}</span>
+                  {s.years && <span className="text-[#d7ba7d]">{s.years}y</span>}
+                </div>
+              ))}
+            </div>
+          </Section>
+        )
+      })}
+    </div>
+  )
+}
+
+function ExperienceContent() {
+  return (
+    <div className="space-y-4">
+      <div className="text-[#608b4e]">{`# Experience`}</div>
+      {experienceData.map(exp => (
+        <Section key={exp.id} title={`${exp.company} — ${exp.title}`}>
+          <div className="text-[#858585] text-xs mb-2">{exp.duration}</div>
+          <div className="text-[#ce9178] text-sm mb-2">{exp.description}</div>
+          <div className="space-y-0.5">
+            {exp.achievements.map((a, i) => (
+              <div key={i} className="text-sm flex gap-2">
+                <span className="text-[#608b4e] shrink-0">+</span>
+                <span className="text-[#d4d4d4]">{a}</span>
+              </div>
+            ))}
+          </div>
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {exp.tech.map(t => (
+              <span key={t} className="px-1.5 py-0.5 text-[10px] bg-[#1a1a1a] text-[#4ec9b0] border border-[#3c3c3c]">
+                {t}
+              </span>
+            ))}
+          </div>
+        </Section>
+      ))}
+    </div>
+  )
+}
+
+function ProjectsContent() {
+  return (
+    <div className="space-y-4">
+      <div className="text-[#608b4e]">{`# Projects`}</div>
+      <div className="text-[#858585] text-xs mb-4">
+        {projectsData.length} projects total | Sorted by tier
+      </div>
+      {(["flagship", "strong", "supporting"] as const).map(tier => {
+        const projects = projectsData.filter(p => p.tier === tier)
+        const tierLabel = tier.toUpperCase()
+        return (
+          <Section key={tier} title={`[${tierLabel}]`}>
+            <div className="space-y-3">
+              {projects.map(p => (
+                <div key={p.id} className="text-sm">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-[#4ec9b0] font-bold">{p.title}</span>
+                    <span className="text-[#858585]">—</span>
+                    <span className="text-[#d7ba7d] text-xs">{p.category}</span>
+                    {p.status === "production" && (
+                      <span className="text-[10px] px-1 py-0.5 bg-[#608b4e]/20 text-[#608b4e] border border-[#608b4e]/30">LIVE</span>
+                    )}
+                  </div>
+                  <div className="text-[#ce9178] text-xs mt-0.5">{p.tagline}</div>
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {p.tech.slice(0, 5).map(t => (
+                      <span key={t} className="text-[10px] text-[#858585]">{t}</span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Section>
+        )
+      })}
+    </div>
+  )
+}
+
+function BlogContent() {
+  return (
+    <div className="space-y-4">
+      <div className="text-[#608b4e]">{`# Blog`}</div>
+      {blogPosts.map(post => (
+        <Section key={post.id} title={post.title}>
+          <div className="flex items-center gap-3 text-xs text-[#858585] mb-2">
+            <span>{post.date}</span>
+            <span>{post.readTime} min read</span>
+            <span className="text-[#d7ba7d]">{post.category}</span>
+          </div>
+          <div className="text-sm text-[#ce9178]">{post.excerpt}</div>
+          <div className="mt-3 text-sm text-[#d4d4d4] whitespace-pre-wrap leading-relaxed">
+            {post.content.slice(0, 500)}
+            {post.content.length > 500 && <span className="text-[#858585]">... [truncated]</span>}
+          </div>
+        </Section>
+      ))}
+    </div>
+  )
+}
+
+function ContactContent() {
+  return (
+    <div className="space-y-4">
+      <div className="text-[#608b4e]">{`#!/bin/bash`}</div>
+      <div className="text-[#608b4e]">{`# CONTACT.sh — Get in touch`}</div>
+      <div className="mt-4 space-y-2">
+        <div className="text-sm">
+          <span className="text-[#569cd6]">EMAIL</span><span className="text-[#d4d4d4]">=</span>
+          <a href="mailto:daniel@interestingandbeyond.com" className="text-[#ce9178] hover:underline">"daniel@interestingandbeyond.com"</a>
+        </div>
+        <div className="text-sm">
+          <span className="text-[#569cd6]">GITHUB</span><span className="text-[#d4d4d4]">=</span>
+          <a href="https://github.com/dmhernandez2525" target="_blank" rel="noopener noreferrer" className="text-[#ce9178] hover:underline">"https://github.com/dmhernandez2525"</a>
+        </div>
+        <div className="text-sm">
+          <span className="text-[#569cd6]">LINKEDIN</span><span className="text-[#d4d4d4]">=</span>
+          <a href="https://linkedin.com/in/dh25" target="_blank" rel="noopener noreferrer" className="text-[#ce9178] hover:underline">"https://linkedin.com/in/dh25"</a>
+        </div>
+      </div>
+      <div className="mt-6 bg-[#1a1a1a] p-3 text-xs space-y-1">
+        <div className="text-[#608b4e]"># Quick connect</div>
+        <div><span className="text-[#569cd6]">$</span> echo "Let's build something together" | mail -s "Hello" $EMAIL</div>
+      </div>
+    </div>
+  )
+}
+
+function GameLoader({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense fallback={
+      <div className="flex items-center justify-center h-full text-[#858585] font-mono text-sm">
+        Loading executable...
+      </div>
+    }>
+      <div className="h-full overflow-auto">{children}</div>
+    </Suspense>
+  )
+}
+
+function WelcomeScreen() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full text-[#858585] font-mono">
+      <div className="text-2xl mb-2 text-[#569cd6]">DH OS v1.0.0</div>
+      <div className="text-sm mb-6">Select a file from the explorer to get started</div>
+      <div className="text-xs space-y-1 text-center">
+        <div>Tip: Start with <span className="text-[#4ec9b0]">README.md</span></div>
+        <div>or try running <span className="text-[#4ec9b0]">snake.exe</span></div>
+      </div>
+    </div>
+  )
+}
+
+function TechieEditor({ tab, onEditorChange }: { tab: TechieTab; onEditorChange: (tabId: string, content: string) => void }) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const lineCount = (tab.editorContent ?? "").split("\n").length
+
+  useEffect(() => {
+    textareaRef.current?.focus()
+  }, [tab.id])
+
+  return (
+    <div className="flex h-full">
+      {/* Line numbers */}
+      <div className="py-4 px-2 text-right select-none text-[#858585] text-xs leading-[1.5rem] bg-[#1e1e1e] border-r border-[#3c3c3c] w-12 shrink-0">
+        {Array.from({ length: Math.max(lineCount, 20) }, (_, i) => (
+          <div key={i}>{i + 1}</div>
+        ))}
+      </div>
+      {/* Editor area */}
+      <textarea
+        ref={textareaRef}
+        value={tab.editorContent ?? ""}
+        onChange={(e) => onEditorChange(tab.id, e.target.value)}
+        className="flex-1 bg-[#1e1e1e] text-[#d4d4d4] text-sm font-mono p-4 resize-none outline-none leading-[1.5rem] caret-[#aeafad]"
+        spellCheck={false}
+        placeholder="Start typing..."
+      />
+    </div>
+  )
+}
+
+export function TechieContentViewer({ tab, onEditorChange }: TechieContentViewerProps) {
+  if (!tab) return <WelcomeScreen />
+
+  // Untitled/editor tabs
+  if (tab.isUntitled) {
+    return <TechieEditor tab={tab} onEditorChange={onEditorChange} />
+  }
+
+  const contentKey = tab.contentKey
+
+  // Handle games
+  const gameMap: Record<string, React.ReactNode> = {
+    "game-snake": <GameLoader><SnakeGame /></GameLoader>,
+    "game-tetris": <GameLoader><TetrisGame /></GameLoader>,
+    "game-chess": <GameLoader><ChessGame /></GameLoader>,
+    "game-falling-blocks": <GameLoader><FallingBlocksGame /></GameLoader>,
+    "game-cookie-clicker": <GameLoader><CookieClickerGame /></GameLoader>,
+    "game-agar": <GameLoader><AgarGame /></GameLoader>,
+  }
+
+  if (contentKey in gameMap) return <>{gameMap[contentKey]}</>
+
+  // Handle content files
+  const contentMap: Record<string, React.ReactNode> = {
+    readme: <ReadmeContent />,
+    about: <AboutContent />,
+    skills: <SkillsContent />,
+    experience: <ExperienceContent />,
+    projects: <ProjectsContent />,
+    blog: <BlogContent />,
+    contact: <ContactContent />,
+  }
+
+  const content = contentMap[contentKey]
+
+  if (!content) {
+    return (
+      <div className="p-6 text-[#858585] font-mono text-sm">
+        <div className="text-[#f44747]">Error: File not found — {tab.fileName}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 font-mono text-sm text-[#d4d4d4] overflow-auto h-full">
+      {content}
+    </div>
+  )
+}

--- a/src/components/techie/TechieFileExplorer.tsx
+++ b/src/components/techie/TechieFileExplorer.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react"
+import { ChevronDown, ChevronRight } from "lucide-react"
+import { fileTree, getFileIcon, type FileNode } from "./techie-data"
+
+interface TechieFileExplorerProps {
+  currentFile: string | null
+  onFileSelect: (contentKey: string, fileName: string) => void
+}
+
+function FileTreeNode({
+  node,
+  depth,
+  currentFile,
+  onFileSelect,
+}: {
+  node: FileNode
+  depth: number
+  currentFile: string | null
+  onFileSelect: (contentKey: string, fileName: string) => void
+}) {
+  const [expanded, setExpanded] = useState(depth < 2)
+
+  if (node.type === "folder") {
+    return (
+      <div>
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="w-full flex items-center gap-1 px-2 py-0.5 hover:bg-[#2a2d2e] text-left text-[#cccccc] transition-colors"
+          style={{ paddingLeft: `${depth * 12 + 8}px` }}
+        >
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 text-[#858585] shrink-0" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 text-[#858585] shrink-0" />
+          )}
+          <span className="text-xs">{node.name}</span>
+        </button>
+        {expanded &&
+          node.children?.map((child) => (
+            <FileTreeNode
+              key={child.name}
+              node={child}
+              depth={depth + 1}
+              currentFile={currentFile}
+              onFileSelect={onFileSelect}
+            />
+          ))}
+      </div>
+    )
+  }
+
+  const isActive = currentFile === node.contentKey
+  const icon = getFileIcon(node.name)
+
+  return (
+    <button
+      onClick={() => node.contentKey && onFileSelect(node.contentKey, node.name)}
+      className={`w-full flex items-center gap-1.5 px-2 py-0.5 text-left text-xs transition-colors ${
+        isActive ? "bg-[#094771] text-white" : "text-[#cccccc] hover:bg-[#2a2d2e]"
+      }`}
+      style={{ paddingLeft: `${depth * 12 + 8}px` }}
+    >
+      <span className="text-[10px] shrink-0">{icon}</span>
+      <span className={node.name.endsWith(".exe") ? "text-[#4ec9b0]" : ""}>{node.name}</span>
+    </button>
+  )
+}
+
+export function TechieFileExplorer({ currentFile, onFileSelect }: TechieFileExplorerProps) {
+  return (
+    <div className="h-full bg-[#252526] border-r border-[#3c3c3c] overflow-y-auto">
+      <div className="px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-[#bbbbbb]">
+        Explorer
+      </div>
+      {fileTree.map((node) => (
+        <FileTreeNode
+          key={node.name}
+          node={node}
+          depth={0}
+          currentFile={currentFile}
+          onFileSelect={onFileSelect}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/techie/TechieLayout.tsx
+++ b/src/components/techie/TechieLayout.tsx
@@ -1,0 +1,218 @@
+import { useState, useCallback } from "react"
+import { TechieMenuBar } from "./TechieMenuBar"
+import { TechieFileExplorer } from "./TechieFileExplorer"
+import { TechieContentViewer } from "./TechieContentViewer"
+import { TechieTabs } from "./TechieTabs"
+import { TechieStatusBar } from "./TechieStatusBar"
+import { MatrixRain } from "./MatrixRain"
+import { AboutDialog } from "./AboutDialog"
+
+export interface TechieTab {
+  id: string
+  fileName: string
+  contentKey: string
+  isUntitled?: boolean
+  editorContent?: string
+}
+
+export function TechieLayout() {
+  const [tabs, setTabs] = useState<TechieTab[]>([])
+  const [activeTabId, setActiveTabId] = useState<string | null>(null)
+  const [showMatrix, setShowMatrix] = useState(false)
+  const [showAbout, setShowAbout] = useState(false)
+  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [untitledCounter, setUntitledCounter] = useState(1)
+
+  const activeTab = tabs.find(t => t.id === activeTabId) ?? null
+
+  const openFile = useCallback((contentKey: string, fileName: string) => {
+    // External links
+    if (contentKey.startsWith("link-")) {
+      const urls: Record<string, string> = {
+        "link-github": "https://github.com/dmhernandez2525",
+        "link-linkedin": "https://linkedin.com/in/dh25",
+      }
+      const url = urls[contentKey]
+      if (url) window.open(url, "_blank")
+      return
+    }
+
+    // Check if tab already exists
+    const existing = tabs.find(t => t.contentKey === contentKey && !t.isUntitled)
+    if (existing) {
+      setActiveTabId(existing.id)
+      return
+    }
+
+    const newTab: TechieTab = {
+      id: `${contentKey}-${Date.now()}`,
+      fileName,
+      contentKey,
+    }
+    setTabs(prev => [...prev, newTab])
+    setActiveTabId(newTab.id)
+  }, [tabs])
+
+  const createNewFile = useCallback(() => {
+    const num = untitledCounter
+    setUntitledCounter(prev => prev + 1)
+    const newTab: TechieTab = {
+      id: `untitled-${Date.now()}`,
+      fileName: `Untitled-${num}`,
+      contentKey: `untitled-${num}`,
+      isUntitled: true,
+      editorContent: "",
+    }
+    setTabs(prev => [...prev, newTab])
+    setActiveTabId(newTab.id)
+  }, [untitledCounter])
+
+  const closeTab = useCallback((tabId: string) => {
+    setTabs(prev => {
+      const idx = prev.findIndex(t => t.id === tabId)
+      const next = prev.filter(t => t.id !== tabId)
+      if (activeTabId === tabId) {
+        // Activate adjacent tab
+        if (next.length > 0) {
+          const newIdx = Math.min(idx, next.length - 1)
+          setActiveTabId(next[newIdx].id)
+        } else {
+          setActiveTabId(null)
+        }
+      }
+      return next
+    })
+  }, [activeTabId])
+
+  const updateEditorContent = useCallback((tabId: string, content: string) => {
+    setTabs(prev => prev.map(t =>
+      t.id === tabId ? { ...t, editorContent: content } : t
+    ))
+  }, [])
+
+  const handleMenuAction = useCallback((action: string) => {
+    switch (action) {
+      case "new-file":
+        createNewFile()
+        break
+      case "toggle-sidebar":
+        setSidebarOpen(prev => !prev)
+        break
+      case "panic":
+        setShowMatrix(true)
+        break
+      case "about":
+        setShowAbout(true)
+        break
+    }
+  }, [createNewFile])
+
+  return (
+    <div className="h-screen w-screen flex flex-col bg-[#1e1e1e] text-[#d4d4d4] font-mono overflow-hidden select-none">
+      {/* Window chrome with traffic lights */}
+      <div className="flex items-center bg-[#323233] border-b border-[#3c3c3c]">
+        <div className="flex items-center gap-2 px-4 py-2.5 shrink-0">
+          <div className="w-3 h-3 rounded-full bg-[#ff5f57] border border-[#e0443e]" />
+          <div className="w-3 h-3 rounded-full bg-[#febc2e] border border-[#d4a528]" />
+          <div className="w-3 h-3 rounded-full bg-[#28c840] border border-[#1aab29]" />
+        </div>
+        <TechieMenuBar onAction={handleMenuAction} />
+      </div>
+
+      {/* Tab bar */}
+      <TechieTabs
+        tabs={tabs}
+        activeTabId={activeTabId}
+        onActivate={setActiveTabId}
+        onClose={closeTab}
+      />
+
+      {/* Breadcrumb */}
+      <div className="flex items-center px-4 py-1 bg-[#252526] border-b border-[#3c3c3c] text-xs text-[#858585]">
+        <span className="text-[#cccccc]">daniel-hernandez</span>
+        {activeTab && (
+          <>
+            <span className="mx-1.5">&gt;</span>
+            <span className="text-[#cccccc]">{activeTab.fileName}</span>
+          </>
+        )}
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Sidebar */}
+        {sidebarOpen && (
+          <div className="w-56 shrink-0 hidden sm:block">
+            <TechieFileExplorer
+              currentFile={activeTab?.contentKey ?? null}
+              onFileSelect={openFile}
+            />
+          </div>
+        )}
+
+        {/* Main content */}
+        <div className="flex-1 overflow-auto bg-[#1e1e1e]">
+          <TechieContentViewer
+            tab={activeTab}
+            onEditorChange={updateEditorContent}
+          />
+        </div>
+      </div>
+
+      <TechieStatusBar
+        currentFile={activeTab?.fileName ?? ""}
+        lineCount={activeTab?.isUntitled ? (activeTab.editorContent?.split("\n").length ?? 1) : undefined}
+      />
+
+      {/* Mobile sidebar */}
+      <MobileSidebar
+        currentFile={activeTab?.contentKey ?? null}
+        onFileSelect={openFile}
+        sidebarOpen={sidebarOpen}
+      />
+
+      {/* Overlays */}
+      {showMatrix && <MatrixRain onDismiss={() => setShowMatrix(false)} />}
+      {showAbout && <AboutDialog onClose={() => setShowAbout(false)} />}
+    </div>
+  )
+}
+
+function MobileSidebar({
+  currentFile,
+  onFileSelect,
+  sidebarOpen,
+}: {
+  currentFile: string | null
+  onFileSelect: (contentKey: string, fileName: string) => void
+  sidebarOpen: boolean
+}) {
+  const [open, setOpen] = useState(false)
+
+  if (sidebarOpen) return null
+
+  return (
+    <div className="sm:hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        className="fixed top-1 right-2 z-50 px-2 py-1 bg-[#252526] border border-[#3c3c3c] text-[#cccccc] text-xs font-mono"
+      >
+        {open ? "Close" : "Files"}
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-40 flex">
+          <div className="absolute inset-0 bg-black/60" onClick={() => setOpen(false)} />
+          <div className="relative w-64 bg-[#252526] border-r border-[#3c3c3c] overflow-y-auto">
+            <TechieFileExplorer
+              currentFile={currentFile}
+              onFileSelect={(key, name) => {
+                onFileSelect(key, name)
+                setOpen(false)
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/techie/TechieMenuBar.tsx
+++ b/src/components/techie/TechieMenuBar.tsx
@@ -1,0 +1,151 @@
+import { useState, useEffect, useRef } from "react"
+import { useMode } from "@/context/mode-context"
+
+interface MenuItem {
+  label: string
+  shortcut?: string
+  action?: string
+}
+
+interface MenuGroup {
+  label: string
+  items: MenuItem[]
+}
+
+const menus: MenuGroup[] = [
+  {
+    label: "File",
+    items: [
+      { label: "New File", shortcut: "Ctrl+N", action: "new-file" },
+      { label: "separator" },
+      { label: "Print...", shortcut: "Ctrl+P", action: "print" },
+      { label: "separator" },
+      { label: "Exit to Gateway", shortcut: "Ctrl+Q", action: "exit" },
+    ],
+  },
+  {
+    label: "Edit",
+    items: [
+      { label: "Copy", shortcut: "Ctrl+C" },
+      { label: "Cut", shortcut: "Ctrl+X" },
+      { label: "Paste", shortcut: "Ctrl+V" },
+      { label: "separator" },
+      { label: "Find", shortcut: "Ctrl+F" },
+    ],
+  },
+  {
+    label: "View",
+    items: [
+      { label: "Toggle Sidebar", shortcut: "Ctrl+B", action: "toggle-sidebar" },
+      { label: "separator" },
+      { label: "Zoom In", shortcut: "Ctrl+=" },
+      { label: "Zoom Out", shortcut: "Ctrl+-" },
+    ],
+  },
+  {
+    label: "Go",
+    items: [
+      { label: "Go to File...", shortcut: "Ctrl+P" },
+      { label: "Go to Line...", shortcut: "Ctrl+G" },
+    ],
+  },
+  {
+    label: "Window",
+    items: [
+      { label: "New Window", shortcut: "Ctrl+Shift+N" },
+    ],
+  },
+  {
+    label: "Help",
+    items: [
+      { label: "About DH OS", action: "about" },
+      { label: "separator" },
+      { label: "Panic!", action: "panic" },
+    ],
+  },
+]
+
+interface TechieMenuBarProps {
+  onAction: (action: string) => void
+}
+
+export function TechieMenuBar({ onAction }: TechieMenuBarProps) {
+  const { clearMode } = useMode()
+  const [openMenu, setOpenMenu] = useState<string | null>(null)
+  const [time, setTime] = useState(new Date())
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const timer = setInterval(() => setTime(new Date()), 1000)
+    return () => clearInterval(timer)
+  }, [])
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpenMenu(null)
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [])
+
+  const handleItemClick = (action?: string) => {
+    setOpenMenu(null)
+    if (!action) return
+    if (action === "exit") {
+      clearMode()
+      return
+    }
+    if (action === "print") {
+      window.print()
+      return
+    }
+    onAction(action)
+  }
+
+  return (
+    <div ref={menuRef} className="flex items-center justify-between flex-1 text-[#cccccc] text-xs font-mono select-none">
+      <div className="flex items-center">
+        {menus.map((menu) => (
+          <div key={menu.label} className="relative">
+            <button
+              onClick={() => setOpenMenu(openMenu === menu.label ? null : menu.label)}
+              onMouseEnter={() => openMenu && setOpenMenu(menu.label)}
+              className={`px-3 py-1.5 transition-colors ${
+                openMenu === menu.label ? "bg-[#505050]" : "hover:bg-[#3c3c3c]"
+              }`}
+            >
+              {menu.label}
+            </button>
+
+            {openMenu === menu.label && (
+              <div className="absolute top-full left-0 min-w-[220px] bg-[#252526] border border-[#454545] shadow-xl z-50 py-1">
+                {menu.items.map((item, i) =>
+                  item.label === "separator" ? (
+                    <div key={i} className="border-t border-[#454545] my-1 mx-2" />
+                  ) : (
+                    <button
+                      key={item.label}
+                      onClick={() => handleItemClick(item.action)}
+                      className="w-full flex items-center justify-between px-4 py-1 hover:bg-[#094771] text-left transition-colors"
+                    >
+                      <span>{item.label}</span>
+                      {item.shortcut && (
+                        <span className="text-[#858585] ml-8 text-[10px]">{item.shortcut}</span>
+                      )}
+                    </button>
+                  )
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="px-3 py-1.5 text-[#858585]">
+        {time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/techie/TechieStatusBar.tsx
+++ b/src/components/techie/TechieStatusBar.tsx
@@ -1,0 +1,42 @@
+import { GitBranch, AlertTriangle, XCircle } from "lucide-react"
+
+interface TechieStatusBarProps {
+  currentFile: string
+  lineCount?: number
+}
+
+export function TechieStatusBar({ currentFile, lineCount }: TechieStatusBarProps) {
+  return (
+    <div className="flex items-center justify-between px-3 py-1 bg-[#007acc] text-white text-xs font-mono select-none">
+      <div className="flex items-center gap-4">
+        {/* Git branch */}
+        <div className="flex items-center gap-1">
+          <GitBranch className="h-3 w-3" />
+          <span>main</span>
+        </div>
+
+        {/* Errors / Warnings */}
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-0.5">
+            <XCircle className="h-3 w-3" />
+            <span>0</span>
+          </div>
+          <div className="flex items-center gap-0.5">
+            <AlertTriangle className="h-3 w-3" />
+            <span>0</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4">
+        {currentFile && <span>{currentFile}</span>}
+        {lineCount !== undefined && (
+          <span>Ln {lineCount}, Col 1</span>
+        )}
+        <span>UTF-8</span>
+        <span>LF</span>
+        <span>TypeScript</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/techie/TechieTabs.tsx
+++ b/src/components/techie/TechieTabs.tsx
@@ -1,0 +1,51 @@
+import { X } from "lucide-react"
+import type { TechieTab } from "./TechieLayout"
+import { getFileIcon } from "./techie-data"
+
+interface TechieTabsProps {
+  tabs: TechieTab[]
+  activeTabId: string | null
+  onActivate: (id: string) => void
+  onClose: (id: string) => void
+}
+
+export function TechieTabs({ tabs, activeTabId, onActivate, onClose }: TechieTabsProps) {
+  if (tabs.length === 0) return null
+
+  return (
+    <div className="flex bg-[#252526] border-b border-[#3c3c3c] overflow-x-auto scrollbar-none">
+      {tabs.map((tab) => {
+        const isActive = tab.id === activeTabId
+        const icon = tab.isUntitled ? "\u{1F4C4}" : getFileIcon(tab.fileName)
+
+        return (
+          <div
+            key={tab.id}
+            className={`group flex items-center gap-1.5 px-3 py-1.5 text-xs cursor-pointer border-r border-[#3c3c3c] shrink-0 transition-colors ${
+              isActive
+                ? "bg-[#1e1e1e] text-[#ffffff] border-t-2 border-t-[#007acc]"
+                : "bg-[#2d2d2d] text-[#969696] hover:bg-[#2a2a2a] border-t-2 border-t-transparent"
+            }`}
+            onClick={() => onActivate(tab.id)}
+          >
+            <span className="text-[10px]">{icon}</span>
+            <span className="max-w-[120px] truncate">{tab.fileName}</span>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onClose(tab.id)
+              }}
+              className={`ml-1 p-0.5 rounded-sm transition-colors ${
+                isActive
+                  ? "hover:bg-[#3c3c3c] text-[#cccccc]"
+                  : "opacity-0 group-hover:opacity-100 hover:bg-[#3c3c3c] text-[#969696]"
+              }`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/techie/techie-data.ts
+++ b/src/components/techie/techie-data.ts
@@ -1,0 +1,61 @@
+export interface FileNode {
+  name: string
+  type: "file" | "folder"
+  contentKey?: string
+  children?: FileNode[]
+}
+
+export const fileTree: FileNode[] = [
+  {
+    name: "PORTFOLIO",
+    type: "folder",
+    children: [
+      { name: "README.md", type: "file", contentKey: "readme" },
+      { name: "ABOUT.md", type: "file", contentKey: "about" },
+      { name: "SKILLS.txt", type: "file", contentKey: "skills" },
+      { name: "EXPERIENCE.log", type: "file", contentKey: "experience" },
+      {
+        name: "PROJECTS",
+        type: "folder",
+        children: [
+          { name: "index.md", type: "file", contentKey: "projects" },
+        ],
+      },
+      {
+        name: "GAMES",
+        type: "folder",
+        children: [
+          { name: "snake.exe", type: "file", contentKey: "game-snake" },
+          { name: "tetris.exe", type: "file", contentKey: "game-tetris" },
+          { name: "chess.exe", type: "file", contentKey: "game-chess" },
+          { name: "falling-blocks.exe", type: "file", contentKey: "game-falling-blocks" },
+          { name: "cookie-clicker.exe", type: "file", contentKey: "game-cookie-clicker" },
+          { name: "agar.exe", type: "file", contentKey: "game-agar" },
+        ],
+      },
+      { name: "BLOG.md", type: "file", contentKey: "blog" },
+      { name: "CONTACT.sh", type: "file", contentKey: "contact" },
+      {
+        name: "EXTERNAL",
+        type: "folder",
+        children: [
+          { name: "github.lnk", type: "file", contentKey: "link-github" },
+          { name: "linkedin.lnk", type: "file", contentKey: "link-linkedin" },
+        ],
+      },
+    ],
+  },
+]
+
+export function getFileIcon(name: string): string {
+  const ext = name.split(".").pop()?.toLowerCase()
+  const icons: Record<string, string> = {
+    md: "\u{1F4C4}",
+    txt: "\u{1F4DD}",
+    log: "\u{1F4CB}",
+    sh: "\u{1F4DF}",
+    exe: "\u{1F3AE}",
+    lnk: "\u{1F517}",
+  }
+  return icons[ext ?? ""] ?? "\u{1F4C4}"
+}


### PR DESCRIPTION
## Summary
- Full retro terminal/OS interface with VS Code-inspired layout
- IDE-style tab system with close buttons and deduplication
- File explorer sidebar with recursive folder tree and expand/collapse
- Content viewer renders portfolio sections as terminal-styled "files"
- Menu bar with File, Edit, View, Go, Window, Help menus and live clock
- New File functionality with editable textarea and line numbers
- Easter eggs: Matrix rain (Panic! menu), About DH OS dialog
- Status bar with git branch, error/warning counts, encoding, line info
- Games (snake, tetris, chess, etc.) launch as .exe files from file tree

## Test plan
- [ ] Verify file tree renders with correct folder structure
- [ ] Verify clicking files opens content in tabs
- [ ] Verify tabs can be opened, switched, and closed
- [ ] Verify New File creates editable untitled tab
- [ ] Verify Panic! triggers Matrix rain overlay
- [ ] Verify About DH OS dialog opens and closes
- [ ] Verify games launch from .exe files
- [ ] Verify sidebar toggle works
- [ ] Verify mobile responsive layout