### PR TITLE
Fix LinkedIn URLs to use correct profile

### DIFF
--- a/src/components/shared/Footer.tsx
+++ b/src/components/shared/Footer.tsx
@@ -17,7 +17,7 @@ export function Footer() {
             <Github className="h-5 w-5" />
           </a>
           <a
-            href="https://www.linkedin.com/in/daniel-hernandez-01a15a150/"
+            href="https://www.linkedin.com/in/dh25/"
             target="_blank"
             rel="noopener noreferrer"
             className="p-2 rounded-full bg-background border border-border hover:border-primary hover:text-primary transition-all"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import { SpeechProvider } from './context/speech-context'
 // Console Easter Eggs for curious developers
 console.log("%c👋 Hey, you're curious. I like that.", "font-size: 20px; font-weight: bold;");
 console.log("%c💼 If you're checking out my code, maybe we should work together.", "font-size: 14px;");
-console.log("%c📧 Reach out: https://linkedin.com/in/danielhernandezny", "font-size: 14px;");
+console.log("%c📧 Reach out: https://linkedin.com/in/dh25", "font-size: 14px;");
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <SpeechProvider>


### PR DESCRIPTION
## Summary
- Updates LinkedIn URL from old profile path to correct `/in/dh25`
- Fixed in Footer.tsx social links
- Fixed in main.tsx console easter egg

## Test plan
- [ ] Verify Footer LinkedIn link goes to https://linkedin.com/in/dh25
- [ ] Verify console Easter egg shows correct LinkedIn URL