### PR TITLE
Add hidden files, easter eggs, and Konami code

### DIFF
--- a/src/components/techie/TechieContentViewer.tsx
+++ b/src/components/techie/TechieContentViewer.tsx
@@ -207,6 +207,80 @@ function BlogContent() {
   )
 }
 
+function HiddenEnvContent() {
+  return (
+    <div className="space-y-2">
+      <div className="text-[#608b4e]">{`# .env — Environment Variables`}</div>
+      <div className="text-[#858585] text-xs mb-4">You found a hidden file!</div>
+      <div className="bg-[#1a1a1a] p-4 rounded space-y-1 text-sm">
+        <div><span className="text-[#569cd6]">HIRE_ME</span><span className="text-[#d4d4d4]">=</span><span className="text-[#ce9178]">true</span></div>
+        <div><span className="text-[#569cd6]">COFFEE_LEVEL</span><span className="text-[#d4d4d4]">=</span><span className="text-[#ce9178]">critical</span></div>
+        <div><span className="text-[#569cd6]">BUGS</span><span className="text-[#d4d4d4]">=</span><span className="text-[#ce9178]">0</span></div>
+        <div><span className="text-[#569cd6]">MOTIVATION</span><span className="text-[#d4d4d4]">=</span><span className="text-[#ce9178]">infinite</span></div>
+        <div><span className="text-[#569cd6]">DARK_MODE</span><span className="text-[#d4d4d4]">=</span><span className="text-[#ce9178]">always</span></div>
+        <div><span className="text-[#569cd6]">TABS_VS_SPACES</span><span className="text-[#d4d4d4]">=</span><span className="text-[#ce9178]">tabs</span></div>
+        <div><span className="text-[#569cd6]">FAVORITE_EDITOR</span><span className="text-[#d4d4d4]">=</span><span className="text-[#ce9178]">the one that doesn't crash</span></div>
+        <div className="text-[#608b4e] pt-2"># Don't tell anyone about these</div>
+        <div><span className="text-[#569cd6]">SECRET_POWER</span><span className="text-[#d4d4d4]">=</span><span className="text-[#ce9178]">turning caffeine into code</span></div>
+        <div><span className="text-[#569cd6]">STACKOVERFLOW_VISITS_TODAY</span><span className="text-[#d4d4d4]">=</span><span className="text-[#ce9178]">42</span></div>
+      </div>
+    </div>
+  )
+}
+
+function HiddenSecretContent() {
+  return (
+    <div className="space-y-4">
+      <div className="text-[#608b4e]">{`# .secret — You found the secret file!`}</div>
+      <div className="bg-[#1a1a1a] p-4 rounded font-mono text-[#4ec9b0] text-xs leading-relaxed whitespace-pre">
+{`    ___       ___       ___       ___
+   /\\  \\     /\\__\\     /\\  \\     /\\  \\
+  /::\\  \\   /:/__/_   _\\:\\  \\   /::\\  \\
+ /:/\\:\\__\\ /::\\/\\__\\ /\\/::\\__\\ /:/\\:\\__\\
+ \\:\\/:/  / \\/\\::/  / \\::/\\/__/ \\:\\ \\/__/
+  \\::/  /    /:/  /   \\:\\__\\    \\:\\__\\
+   \\/__/     \\/__/     \\/__/     \\/__/  `}
+      </div>
+      <div className="text-[#ce9178] text-sm">
+        Congratulations, you found the secret file! You must be the curious type.
+      </div>
+      <div className="text-[#d7ba7d] text-sm">
+        Fun fact: This portfolio has {">"}25 easter eggs hidden throughout.
+        How many can you find?
+      </div>
+      <div className="mt-4 text-xs text-[#858585] space-y-1">
+        <div>Hints:</div>
+        <div className="text-[#608b4e]">+ Try typing certain words while on this page...</div>
+        <div className="text-[#608b4e]">+ The Konami code still works in 2026</div>
+        <div className="text-[#608b4e]">+ The terminal knows more than it lets on</div>
+        <div className="text-[#608b4e]">+ Some commands are... not in the help menu</div>
+      </div>
+    </div>
+  )
+}
+
+function HiddenGitignoreContent() {
+  return (
+    <div className="space-y-2">
+      <div className="text-[#608b4e]">{`# .gitignore`}</div>
+      <div className="bg-[#1a1a1a] p-4 rounded space-y-1 text-sm">
+        <div className="text-[#d4d4d4]">node_modules/</div>
+        <div className="text-[#d4d4d4]">dist/</div>
+        <div className="text-[#d4d4d4]">.env</div>
+        <div className="text-[#d4d4d4]">.DS_Store</div>
+        <div className="text-[#d4d4d4]">*.log</div>
+        <div className="text-[#d4d4d4]">coverage/</div>
+        <div className="text-[#608b4e]"># The important stuff</div>
+        <div className="text-[#d4d4d4]">my-hopes-and-dreams/</div>
+        <div className="text-[#d4d4d4]">passwords-definitely-not-here.txt</div>
+        <div className="text-[#d4d4d4]">evidence/</div>
+        <div className="text-[#d4d4d4]">todo-learn-vim.md</div>
+        <div className="text-[#d4d4d4]">*.tears</div>
+      </div>
+    </div>
+  )
+}
+
 function ContactContent() {
   return (
     <div className="space-y-4">
@@ -319,6 +393,9 @@ export function TechieContentViewer({ tab, onEditorChange }: TechieContentViewer
     projects: <ProjectsContent />,
     blog: <BlogContent />,
     contact: <ContactContent />,
+    "hidden-env": <HiddenEnvContent />,
+    "hidden-secret": <HiddenSecretContent />,
+    "hidden-gitignore": <HiddenGitignoreContent />,
   }
 
   const content = contentMap[contentKey]

--- a/src/components/techie/TechieFileExplorer.tsx
+++ b/src/components/techie/TechieFileExplorer.tsx
@@ -5,6 +5,7 @@ import { fileTree, getFileIcon, type FileNode } from "./techie-data"
 interface TechieFileExplorerProps {
   currentFile: string | null
   onFileSelect: (contentKey: string, fileName: string) => void
+  showHidden?: boolean
 }
 
 function FileTreeNode({
@@ -12,15 +13,21 @@ function FileTreeNode({
   depth,
   currentFile,
   onFileSelect,
+  showHidden,
 }: {
   node: FileNode
   depth: number
   currentFile: string | null
   onFileSelect: (contentKey: string, fileName: string) => void
+  showHidden: boolean
 }) {
   const [expanded, setExpanded] = useState(depth < 2)
 
   if (node.type === "folder") {
+    const visibleChildren = showHidden
+      ? node.children
+      : node.children?.filter((child) => !child.hidden)
+
     return (
       <div>
         <button
@@ -36,13 +43,14 @@ function FileTreeNode({
           <span className="text-xs">{node.name}</span>
         </button>
         {expanded &&
-          node.children?.map((child) => (
+          visibleChildren?.map((child) => (
             <FileTreeNode
               key={child.name}
               node={child}
               depth={depth + 1}
               currentFile={currentFile}
               onFileSelect={onFileSelect}
+              showHidden={showHidden}
             />
           ))}
       </div>
@@ -51,22 +59,23 @@ function FileTreeNode({
 
   const isActive = currentFile === node.contentKey
   const icon = getFileIcon(node.name)
+  const isHidden = node.hidden
 
   return (
     <button
       onClick={() => node.contentKey && onFileSelect(node.contentKey, node.name)}
       className={`w-full flex items-center gap-1.5 px-2 py-0.5 text-left text-xs transition-colors ${
-        isActive ? "bg-[#094771] text-white" : "text-[#cccccc] hover:bg-[#2a2d2e]"
+        isActive ? "bg-[#094771] text-white" : isHidden ? "text-[#6a6a6a] hover:bg-[#2a2d2e]" : "text-[#cccccc] hover:bg-[#2a2d2e]"
       }`}
       style={{ paddingLeft: `${depth * 12 + 8}px` }}
     >
       <span className="text-[10px] shrink-0">{icon}</span>
-      <span className={node.name.endsWith(".exe") ? "text-[#4ec9b0]" : ""}>{node.name}</span>
+      <span className={node.name.endsWith(".exe") ? "text-[#4ec9b0]" : isHidden ? "italic" : ""}>{node.name}</span>
     </button>
   )
 }
 
-export function TechieFileExplorer({ currentFile, onFileSelect }: TechieFileExplorerProps) {
+export function TechieFileExplorer({ currentFile, onFileSelect, showHidden = false }: TechieFileExplorerProps) {
   return (
     <div className="h-full bg-[#252526] border-r border-[#3c3c3c] overflow-y-auto">
       <div className="px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-[#bbbbbb]">
@@ -79,6 +88,7 @@ export function TechieFileExplorer({ currentFile, onFileSelect }: TechieFileExpl
           depth={0}
           currentFile={currentFile}
           onFileSelect={onFileSelect}
+          showHidden={showHidden}
         />
       ))}
     </div>

--- a/src/components/techie/TechieLayout.tsx
+++ b/src/components/techie/TechieLayout.tsx
@@ -10,6 +10,7 @@ import { AboutDialog } from "./AboutDialog"
 import { CommandPalette } from "./dialogs/CommandPalette"
 import { KeyboardShortcutsDialog } from "./dialogs/KeyboardShortcutsDialog"
 import { ReleaseNotesDialog } from "./dialogs/ReleaseNotesDialog"
+import { useEasterEggs } from "@/hooks/use-easter-eggs"
 
 export interface TechieTab {
   id: string
@@ -33,6 +34,8 @@ export function TechieLayout() {
   const [showCommandPalette, setShowCommandPalette] = useState(false)
   const [showShortcuts, setShowShortcuts] = useState(false)
   const [showReleaseNotes, setShowReleaseNotes] = useState(false)
+  const [showHiddenFiles, setShowHiddenFiles] = useState(false)
+  const [easterEggToast, setEasterEggToast] = useState<string | null>(null)
 
   const activeTab = tabs.find(t => t.id === activeTabId) ?? null
 
@@ -42,6 +45,33 @@ export function TechieLayout() {
     const timer = setTimeout(() => setHackerMode(false), 10000)
     return () => clearTimeout(timer)
   }, [hackerMode])
+
+  // Easter egg toast auto-dismiss
+  useEffect(() => {
+    if (!easterEggToast) return
+    const timer = setTimeout(() => setEasterEggToast(null), 3000)
+    return () => clearTimeout(timer)
+  }, [easterEggToast])
+
+  // Easter egg keyboard triggers
+  useEasterEggs({
+    onKonami: useCallback(() => {
+      setShowHiddenFiles(true)
+      setEasterEggToast("Hidden files revealed! Check the explorer.")
+    }, []),
+    onGandalf: useCallback(() => {
+      setEasterEggToast("You shall not pass! ...but you can browse.")
+    }, []),
+    onDaniel: useCallback(() => {
+      setShowAbout(true)
+    }, []),
+    onGhost: useCallback(() => {
+      setEasterEggToast("Boo! ...did I scare you?")
+    }, []),
+    onMonkey: useCallback(() => {
+      setEasterEggToast("Monkey mode activated! Just kidding.")
+    }, []),
+  })
 
   const openFile = useCallback((contentKey: string, fileName: string) => {
     // External links
@@ -255,6 +285,7 @@ export function TechieLayout() {
             <TechieFileExplorer
               currentFile={activeTab?.contentKey ?? null}
               onFileSelect={openFile}
+              showHidden={showHiddenFiles}
             />
           </div>
         )}
@@ -304,6 +335,7 @@ export function TechieLayout() {
         currentFile={activeTab?.contentKey ?? null}
         onFileSelect={openFile}
         sidebarOpen={sidebarOpen}
+        showHidden={showHiddenFiles}
       />
 
       {/* Overlays */}
@@ -317,6 +349,13 @@ export function TechieLayout() {
       )}
       {showShortcuts && <KeyboardShortcutsDialog onClose={() => setShowShortcuts(false)} />}
       {showReleaseNotes && <ReleaseNotesDialog onClose={() => setShowReleaseNotes(false)} />}
+
+      {/* Easter egg toast */}
+      {easterEggToast && (
+        <div className="fixed top-12 left-1/2 -translate-x-1/2 z-50 bg-[#252526] border border-[#454545] px-4 py-2 text-xs text-[#4ec9b0] font-mono shadow-xl">
+          {easterEggToast}
+        </div>
+      )}
     </div>
   )
 }
@@ -325,10 +364,12 @@ function MobileSidebar({
   currentFile,
   onFileSelect,
   sidebarOpen,
+  showHidden,
 }: {
   currentFile: string | null
   onFileSelect: (contentKey: string, fileName: string) => void
   sidebarOpen: boolean
+  showHidden: boolean
 }) {
   const [open, setOpen] = useState(false)
 
@@ -353,6 +394,7 @@ function MobileSidebar({
                 onFileSelect(key, name)
                 setOpen(false)
               }}
+              showHidden={showHidden}
             />
           </div>
         </div>

--- a/src/components/techie/techie-data.ts
+++ b/src/components/techie/techie-data.ts
@@ -3,6 +3,7 @@ export interface FileNode {
   type: "file" | "folder"
   contentKey?: string
   children?: FileNode[]
+  hidden?: boolean
 }
 
 export const fileTree: FileNode[] = [
@@ -33,6 +34,9 @@ export const fileTree: FileNode[] = [
           { name: "agar.exe", type: "file", contentKey: "game-agar" },
         ],
       },
+      { name: ".env", type: "file", contentKey: "hidden-env", hidden: true },
+      { name: ".secret", type: "file", contentKey: "hidden-secret", hidden: true },
+      { name: ".gitignore", type: "file", contentKey: "hidden-gitignore", hidden: true },
       { name: "BLOG.md", type: "file", contentKey: "blog" },
       { name: "CONTACT.sh", type: "file", contentKey: "contact" },
       {
@@ -48,6 +52,9 @@ export const fileTree: FileNode[] = [
 ]
 
 export function getFileIcon(name: string): string {
+  // Dotfiles get a lock icon
+  if (name.startsWith(".")) return "\u{1F512}"
+
   const ext = name.split(".").pop()?.toLowerCase()
   const icons: Record<string, string> = {
     md: "\u{1F4C4}",

--- a/src/components/techie/terminal/terminal-commands.ts
+++ b/src/components/techie/terminal/terminal-commands.ts
@@ -1,15 +1,14 @@
-import { type FileNode, getFileIcon } from "../techie-data"
+import { getFileIcon } from "../techie-data"
 import {
   resolvePath,
   listDirectory,
   buildTreeString,
-  displayPath,
   HOME_PATH,
   normalizePath,
 } from "./terminal-filesystem"
 
 export interface OutputLine {
-  text: string
+  text?: string
   color?: string
   bold?: boolean
   parts?: { text: string; color?: string }[]

--- a/src/components/techie/terminal/terminal-filesystem.ts
+++ b/src/components/techie/terminal/terminal-filesystem.ts
@@ -130,8 +130,6 @@ export function buildTreeString(
   if (!node) return ["No such directory"]
 
   const lines: string[] = []
-  const displayName =
-    node.name || absolutePath === ROOT_PATH ? "/" : absolutePath
   lines.push(node.name || "/")
 
   function walk(parent: FileNode, prefix: string) {


### PR DESCRIPTION
## Summary
- Adds hidden dotfiles (.env, .secret, .gitignore) to the virtual file tree with humorous content
- Integrates `useEasterEggs` hook into TechieLayout — Konami code reveals hidden files in the explorer, typing "gandalf"/"daniel"/"ghost"/"monkey" triggers toast messages or opens About dialog
- Hidden files render with dimmed/italic styling in the explorer when revealed
- Fixes pre-existing TypeScript build errors in terminal modules (OutputLine type, unused imports)

## Test plan
- [ ] Enter Konami code (up up down down left right left right b a) → hidden files appear in explorer
- [ ] Type "gandalf" → toast: "You shall not pass!"
- [ ] Type "daniel" → About dialog opens
- [ ] Click .env in explorer → see humorous environment variables
- [ ] Click .secret → see ASCII art + hints about other easter eggs
- [ ] Click .gitignore → see funny gitignore entries
- [ ] `ls -a` in terminal → shows hidden dotfiles
- [ ] `npm run build` passes with no TypeScript errors