### PR TITLE
Add QR codes to printable resume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,9 @@
         "gsap": "^3.14.2",
         "lenis": "^1.3.17",
         "lucide-react": "^0.563.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
-        "react-dom": "^19.2.0",
+        "react-dom": "^19.2.4",
         "react-hook-form": "^7.71.0",
         "react-joystick-component": "^6.2.1",
         "react-markdown": "^10.1.0",
@@ -6779,6 +6780,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/quickselect": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
@@ -6813,15 +6823,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.4"
       }
     },
     "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gsap": "^3.14.2",
     "lenis": "^1.3.17",
     "lucide-react": "^0.563.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.0",

--- a/src/index.css
+++ b/src/index.css
@@ -299,3 +299,23 @@
 .hacker-mode .bg-\[\#007acc\] {
   background-color: #003300 !important;
 }
+
+/* Print styles for resume */
+@media print {
+  body {
+    background-image: none !important;
+    background: white !important;
+    color: black !important;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0s !important;
+    transition-duration: 0s !important;
+  }
+
+  section {
+    break-inside: avoid;
+  }
+}

--- a/src/pages/ResumePage.tsx
+++ b/src/pages/ResumePage.tsx
@@ -1,8 +1,33 @@
 import { motion } from "framer-motion"
 import { Download, Github, Linkedin, Mail, Printer } from "lucide-react"
+import { QRCodeSVG } from "qrcode.react"
 import { experienceData } from "@/data/experience"
 import { skillsData, type SkillCategory } from "@/data/skills"
 import { projectsData } from "@/data/projects"
+
+const QR_LINKS = [
+  { label: "GitHub", url: "https://github.com/dmhernandez2525" },
+  { label: "LinkedIn", url: "https://linkedin.com/in/dh25" },
+  { label: "Portfolio", url: "https://interestingandbeyond.com" },
+] as const
+
+function ResumeQRCodes() {
+  return (
+    <div className="hidden print:block mt-8 pt-6 border-t border-border">
+      <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-4">
+        Scan to Connect
+      </h2>
+      <div className="flex items-start gap-8">
+        {QR_LINKS.map((link) => (
+          <div key={link.label} className="flex flex-col items-center gap-2">
+            <QRCodeSVG value={link.url} size={80} level="M" />
+            <span className="text-xs text-muted-foreground">{link.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
 
 const fadeIn = {
   initial: { opacity: 0, y: 12 },
@@ -121,6 +146,9 @@ export function ResumePage() {
             ))}
           </div>
         </motion.section>
+
+        {/* QR codes - visible only in print */}
+        <ResumeQRCodes />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- QR codes for GitHub, LinkedIn, and portfolio URL hidden on screen but visible in print
- Uses `qrcode.react` SVG rendering for crisp output at any print DPI
- Global print styles: removes background gradients, disables animations, prevents page breaks inside sections

## Test plan
- [ ] Open resume mode → no QR codes visible on screen
- [ ] Cmd+P / Ctrl+P → QR codes appear in print preview below "Selected Projects"
- [ ] Scan each QR code → correct URLs (GitHub, LinkedIn, portfolio)
- [ ] Print layout fits cleanly on pages
- [ ] `npm run build` passes