### PR TITLE
Add Retro Terminal mode with CRT effects

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -1,10 +1,11 @@
 import { Routes, Route } from "react-router-dom"
-import { useMode } from "@/context/mode-context"
+import { useMode, type PortfolioMode } from "@/context/mode-context"
 import { RootLayout } from "@/components/layout/RootLayout"
 import { Gateway } from "@/pages/Gateway"
 import { BusinessCardPage } from "@/pages/BusinessCardPage"
 import { ResumePage } from "@/pages/ResumePage"
 import { TechieLayout } from "@/components/techie/TechieLayout"
+import { RetroTerminalPage } from "@/pages/RetroTerminalPage"
 
 import { Hero } from "@/components/sections/Hero"
 import { About } from "@/components/sections/About"
@@ -82,6 +83,13 @@ function CreativeRoutes() {
   )
 }
 
+const MODE_PAGES: Partial<Record<PortfolioMode, React.ReactElement>> = {
+  "business-card": <BusinessCardPage />,
+  "resume": <ResumePage />,
+  "techie": <TechieLayout />,
+  "retro": <RetroTerminalPage />,
+}
+
 export function AppRoutes() {
   const { mode } = useMode()
 
@@ -93,30 +101,22 @@ export function AppRoutes() {
     )
   }
 
-  if (mode === 'business-card') {
+  // Creative mode has nested sub-routes
+  if (mode === "creative") return <CreativeRoutes />
+
+  const page = MODE_PAGES[mode]
+  if (page) {
     return (
       <Routes>
-        <Route path="*" element={<BusinessCardPage />} />
+        <Route path="*" element={page} />
       </Routes>
     )
   }
 
-  if (mode === 'resume') {
-    return (
-      <Routes>
-        <Route path="*" element={<ResumePage />} />
-      </Routes>
-    )
-  }
-
-  if (mode === 'techie') {
-    return (
-      <Routes>
-        <Route path="*" element={<TechieLayout />} />
-      </Routes>
-    )
-  }
-
-  // mode === 'creative'
-  return <CreativeRoutes />
+  // Fallback for modes without pages yet (e.g., dashboard)
+  return (
+    <Routes>
+      <Route path="*" element={<Gateway />} />
+    </Routes>
+  )
 }

--- a/src/components/retro/CRTFrame.tsx
+++ b/src/components/retro/CRTFrame.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react"
+
+interface CRTFrameProps {
+  children: ReactNode
+  colorScheme: "green" | "amber"
+}
+
+export function CRTFrame({ children, colorScheme }: CRTFrameProps) {
+  const glowColor = colorScheme === "green"
+    ? "rgba(51, 255, 51, 0.05)"
+    : "rgba(255, 176, 0, 0.05)"
+
+  return (
+    <div className="h-screen w-screen bg-[#111] flex items-center justify-center p-2 sm:p-6">
+      {/* Monitor bezel */}
+      <div
+        className="relative w-full h-full max-w-5xl max-h-[90vh] bg-[#222] rounded-2xl sm:rounded-3xl shadow-2xl overflow-hidden"
+        style={{
+          boxShadow: "0 0 40px rgba(0,0,0,0.8), inset 0 2px 4px rgba(255,255,255,0.05)",
+        }}
+      >
+        {/* Inner screen */}
+        <div
+          className="relative w-full h-full m-0 sm:m-3 rounded-xl sm:rounded-2xl overflow-hidden retro-crt-screen"
+          style={{
+            boxShadow: `inset 0 0 80px ${glowColor}, inset 0 0 160px ${glowColor}`,
+          }}
+        >
+          {/* Content */}
+          <div className="relative z-10 h-full">
+            {children}
+          </div>
+
+          {/* Scanline overlay */}
+          <div className="retro-scanlines absolute inset-0 z-20 pointer-events-none" />
+
+          {/* Vignette */}
+          <div
+            className="absolute inset-0 z-20 pointer-events-none"
+            style={{
+              background: "radial-gradient(ellipse at center, transparent 60%, rgba(0,0,0,0.4) 100%)",
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/retro/RetroAsciiArt.ts
+++ b/src/components/retro/RetroAsciiArt.ts
@@ -1,0 +1,39 @@
+export const ASCII_LOGO = `
+ ____    _    _   _ ___ _____ _
+|  _ \\  / \\  | \\ | |_ _| ____| |
+| | | |/ _ \\ |  \\| || ||  _| | |
+| |_| / ___ \\| |\\  || || |___| |___
+|____/_/   \\_\\_| \\_|___|_____|_____|
+ _   _ _____ ____  _   _    _    _   _ ____  _____ ____
+| | | | ____|  _ \\| \\ | |  / \\  | \\ | |  _ \\| ____|__  /
+| |_| |  _| | |_) |  \\| | / _ \\ |  \\| | | | |  _|   / /
+|  _  | |___|  _ <| |\\  |/ ___ \\| |\\  | |_| | |___ / /_
+|_| |_|_____|_| \\_\\_| \\_/_/   \\_\\_| \\_|____/|_____/____|
+`
+
+export const BOOT_LINES = [
+  "DANIEL-OS v2.0 BIOS",
+  "Copyright (c) 2026 Daniel Hernandez",
+  "",
+  "Checking memory............ 96 GB OK",
+  "Detecting hardware......... M2 Max GPU found",
+  "Loading modules............ [##########] 100%",
+  "Mounting /portfolio........ OK",
+  "Starting terminal service.. OK",
+  "",
+  'Type "help" for available commands.',
+  "",
+]
+
+export const FORTUNES = [
+  '"There are only two hard things in CS: cache invalidation and naming things." — Phil Karlton',
+  '"First, solve the problem. Then, write the code." — John Johnson',
+  '"Code is like humor. When you have to explain it, it\'s bad." — Cory House',
+  '"Any fool can write code that a computer can understand. Good programmers write code that humans can understand." — Martin Fowler',
+  '"The best error message is the one that never shows up." — Thomas Fuchs',
+  '"Talk is cheap. Show me the code." — Linus Torvalds',
+  '"Programs must be written for people to read, and only incidentally for machines to execute." — Harold Abelson',
+  '"Debugging is twice as hard as writing the code in the first place." — Brian Kernighan',
+  '"Simplicity is the soul of efficiency." — Austin Freeman',
+  '"It works on my machine." — Every developer ever',
+]

--- a/src/components/retro/RetroTerminal.tsx
+++ b/src/components/retro/RetroTerminal.tsx
@@ -1,0 +1,111 @@
+import { useRef, useEffect } from "react"
+import { useRetroTerminal } from "./useRetroTerminal"
+import type { RetroLine } from "./retro-commands"
+
+interface RetroTerminalProps {
+  colorScheme: "green" | "amber"
+  onColorChange: (scheme: "green" | "amber") => void
+}
+
+const COLOR_MAP: Record<string, Record<string, string>> = {
+  green: {
+    green: "#33ff33",
+    bright: "#66ff66",
+    dim: "#1a9a1a",
+    cyan: "#33ffcc",
+    red: "#ff4444",
+    amber: "#ffb700",
+  },
+  amber: {
+    green: "#ffb700",
+    bright: "#ffd966",
+    dim: "#996d00",
+    cyan: "#ffe066",
+    red: "#ff4444",
+    amber: "#ffb700",
+  },
+}
+
+function getLineColor(line: RetroLine, scheme: "green" | "amber"): string {
+  const colors = COLOR_MAP[scheme]
+  if (!line.color) return colors.green
+  return colors[line.color] ?? colors.green
+}
+
+export function RetroTerminal({ colorScheme, onColorChange }: RetroTerminalProps) {
+  const outputRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const {
+    lines,
+    currentInput,
+    setCurrentInput,
+    handleKeyDown,
+    bootComplete,
+  } = useRetroTerminal({ onColorChange })
+
+  // Auto-scroll
+  useEffect(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight
+    }
+  }, [lines])
+
+  // Focus input when boot completes
+  useEffect(() => {
+    if (bootComplete) {
+      inputRef.current?.focus()
+    }
+  }, [bootComplete])
+
+  const baseColor = colorScheme === "green" ? "#33ff33" : "#ffb700"
+
+  return (
+    <div
+      className="flex flex-col h-full font-mono text-xs sm:text-sm select-text p-3 sm:p-6"
+      style={{ backgroundColor: "#0a0a0a", color: baseColor }}
+      onClick={() => inputRef.current?.focus()}
+    >
+      {/* Scrollable output */}
+      <div
+        ref={outputRef}
+        className="flex-1 overflow-y-auto overflow-x-hidden leading-6 whitespace-pre-wrap break-words"
+      >
+        {lines.map((line, i) => (
+          <div
+            key={i}
+            style={{ color: getLineColor(line, colorScheme) }}
+            className="retro-text-glow"
+          >
+            {line.text || "\u00A0"}
+          </div>
+        ))}
+      </div>
+
+      {/* Input line */}
+      {bootComplete && (
+        <div className="flex items-center mt-2 shrink-0">
+          <span style={{ color: baseColor }} className="retro-text-glow mr-1">
+            {">"}{" "}
+          </span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={currentInput}
+            onChange={(e) => setCurrentInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="flex-1 bg-transparent outline-none min-w-0"
+            style={{ color: baseColor, caretColor: baseColor }}
+            spellCheck={false}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+          />
+          <span className="retro-cursor" style={{ color: baseColor }}>
+            _
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/retro/retro-commands.ts
+++ b/src/components/retro/retro-commands.ts
@@ -1,0 +1,240 @@
+import { experienceData } from "@/data/experience"
+import { skillsData, type SkillCategory } from "@/data/skills"
+import { projectsData } from "@/data/projects"
+import { FORTUNES } from "./RetroAsciiArt"
+
+export interface RetroLine {
+  text: string
+  color?: "green" | "amber" | "dim" | "bright" | "cyan" | "red"
+}
+
+export interface RetroContext {
+  addLines: (lines: RetroLine[]) => void
+  clear: () => void
+  setColorScheme: (scheme: "green" | "amber") => void
+}
+
+type CommandHandler = (args: string[], ctx: RetroContext) => void
+
+function handleHelp(_args: string[], ctx: RetroContext) {
+  ctx.addLines([
+    { text: "Available commands:", color: "bright" },
+    { text: "" },
+    { text: "  whoami      About me", color: "green" },
+    { text: "  skills      Technical skills", color: "green" },
+    { text: "  experience  Career history", color: "green" },
+    { text: "  projects    Featured projects", color: "green" },
+    { text: "  contact     Get in touch", color: "green" },
+    { text: "" },
+    { text: "  fortune     Random quote", color: "dim" },
+    { text: "  color       Toggle green/amber", color: "dim" },
+    { text: "  clear       Clear screen", color: "dim" },
+    { text: "  help        Show this menu", color: "dim" },
+    { text: "" },
+  ])
+}
+
+function handleWhoami(_args: string[], ctx: RetroContext) {
+  ctx.addLines([
+    { text: "Daniel Hernandez", color: "bright" },
+    { text: "Senior Software Engineer", color: "cyan" },
+    { text: "" },
+    { text: "Self-taught engineer who went from a GED to building DoD" },
+    { text: "applications for Space Force. Co-founded a software" },
+    { text: "consultancy, built 28+ projects, and never stopped learning." },
+    { text: "" },
+    { text: "Beyond code: welding, 3D printing, VR development, PCB" },
+    { text: "soldering, and CAD prototyping. The best engineers build" },
+    { text: "things with their hands." },
+    { text: "" },
+  ])
+}
+
+function handleSkills(_args: string[], ctx: RetroContext) {
+  const categories: SkillCategory[] = ["Frontend", "Backend", "Database", "Cloud", "Beyond Code"]
+  const lines: RetroLine[] = [
+    { text: "Technical Skills", color: "bright" },
+    { text: "=" .repeat(50), color: "dim" },
+  ]
+
+  for (const cat of categories) {
+    const skills = skillsData.filter(s => s.category === cat)
+    lines.push({ text: "" })
+    lines.push({ text: `[${cat.toUpperCase()}]`, color: "cyan" })
+    for (const s of skills) {
+      const level = s.level.padEnd(14)
+      const years = s.years ? `${s.years}y` : "  "
+      lines.push({ text: `  ${s.name.padEnd(20)} ${level} ${years}` })
+    }
+  }
+
+  lines.push({ text: "" })
+  ctx.addLines(lines)
+}
+
+function handleExperience(_args: string[], ctx: RetroContext) {
+  const lines: RetroLine[] = [
+    { text: "Career History", color: "bright" },
+    { text: "=" .repeat(50), color: "dim" },
+    { text: "" },
+  ]
+
+  for (const exp of experienceData) {
+    lines.push({ text: `${exp.company}`, color: "cyan" })
+    lines.push({ text: `  ${exp.title}  (${exp.duration})`, color: "bright" })
+    lines.push({ text: `  ${exp.description}`, color: "dim" })
+    for (const a of exp.achievements.slice(0, 2)) {
+      lines.push({ text: `  + ${a}` })
+    }
+    lines.push({ text: "" })
+  }
+
+  ctx.addLines(lines)
+}
+
+function handleProjects(_args: string[], ctx: RetroContext) {
+  const flagship = projectsData.filter(p => p.tier === "flagship")
+  const lines: RetroLine[] = [
+    { text: "Featured Projects", color: "bright" },
+    { text: "=" .repeat(50), color: "dim" },
+    { text: "" },
+  ]
+
+  for (const [i, p] of flagship.entries()) {
+    const status = p.status === "production" ? "[LIVE]" : `[${p.status.toUpperCase()}]`
+    lines.push({ text: `${(i + 1).toString().padStart(2)}. ${p.title}  ${status}`, color: "cyan" })
+    lines.push({ text: `      ${p.tagline}`, color: "dim" })
+    lines.push({ text: `      Tech: ${p.tech.slice(0, 4).join(", ")}` })
+    lines.push({ text: "" })
+  }
+
+  ctx.addLines(lines)
+}
+
+function handleContact(_args: string[], ctx: RetroContext) {
+  ctx.addLines([
+    { text: "Contact Information", color: "bright" },
+    { text: "=" .repeat(50), color: "dim" },
+    { text: "" },
+    { text: "  EMAIL     daniel@interestingandbeyond.com", color: "cyan" },
+    { text: "  GITHUB    github.com/dmhernandez2525" },
+    { text: "  LINKEDIN  linkedin.com/in/dh25" },
+    { text: "" },
+    { text: '  $ echo "Let\'s build something" | mail daniel', color: "dim" },
+    { text: "" },
+  ])
+}
+
+function handleFortune(_args: string[], ctx: RetroContext) {
+  const quote = FORTUNES[Math.floor(Math.random() * FORTUNES.length)]
+  ctx.addLines([
+    { text: "" },
+    { text: quote, color: "cyan" },
+    { text: "" },
+  ])
+}
+
+function handleColor(_args: string[], ctx: RetroContext) {
+  const scheme = _args[0] === "amber" ? "amber" : _args[0] === "green" ? "green" : null
+  if (!scheme) {
+    ctx.addLines([{ text: 'Usage: color <green|amber>', color: "dim" }])
+    return
+  }
+  ctx.setColorScheme(scheme)
+  ctx.addLines([{ text: `Color scheme set to ${scheme}`, color: "bright" }])
+}
+
+function handleClear(_args: string[], ctx: RetroContext) {
+  ctx.clear()
+}
+
+function handleSudo(args: string[], ctx: RetroContext) {
+  const full = args.join(" ")
+  if (full.includes("hire daniel")) {
+    ctx.addLines([
+      { text: "" },
+      { text: "ACCESS GRANTED", color: "bright" },
+      { text: "Sending offer letter to daniel@interestingandbeyond.com...", color: "cyan" },
+      { text: "Just kidding. But seriously, let's talk!", color: "dim" },
+      { text: "" },
+    ])
+    return
+  }
+  ctx.addLines([
+    { text: "daniel is not in the sudoers file. This incident will be reported.", color: "red" },
+  ])
+}
+
+function handleRm(args: string[], ctx: RetroContext) {
+  if (args.join(" ").includes("-rf /")) {
+    ctx.addLines([
+      { text: "Deleting everything..." },
+      { text: "rm: /portfolio: Operation not permitted", color: "red" },
+      { text: "Nice try. System intact.", color: "dim" },
+      { text: "" },
+    ])
+    return
+  }
+  ctx.addLines([{ text: "rm: permission denied", color: "red" }])
+}
+
+function handleMatrix(_args: string[], ctx: RetroContext) {
+  ctx.addLines([
+    { text: "Wake up, Neo...", color: "bright" },
+    { text: "The Matrix has you...", color: "dim" },
+    { text: "(Matrix rain not available in retro mode. Try the Techie terminal!)", color: "dim" },
+    { text: "" },
+  ])
+}
+
+function handleExit(_args: string[], ctx: RetroContext) {
+  ctx.addLines([
+    { text: "There is no escape from DANIEL-OS.", color: "dim" },
+    { text: 'Use the "Switch Mode" button to leave.', color: "dim" },
+    { text: "" },
+  ])
+}
+
+function handleVim(_args: string[], ctx: RetroContext) {
+  ctx.addLines([
+    { text: "Opening vim... Just kidding, nobody can exit vim.", color: "dim" },
+    { text: "" },
+  ])
+}
+
+const COMMANDS: Record<string, CommandHandler> = {
+  help: handleHelp,
+  whoami: handleWhoami,
+  about: handleWhoami,
+  skills: handleSkills,
+  experience: handleExperience,
+  projects: handleProjects,
+  contact: handleContact,
+  fortune: handleFortune,
+  color: handleColor,
+  clear: handleClear,
+  sudo: handleSudo,
+  rm: handleRm,
+  matrix: handleMatrix,
+  exit: handleExit,
+  vim: handleVim,
+  nano: handleVim,
+}
+
+export function executeRetroCommand(input: string, ctx: RetroContext) {
+  const trimmed = input.trim()
+  if (!trimmed) return
+
+  const parts = trimmed.split(/\s+/)
+  const cmd = parts[0].toLowerCase()
+  const args = parts.slice(1)
+
+  const handler = COMMANDS[cmd]
+  if (handler) {
+    handler(args, ctx)
+  } else {
+    ctx.addLines([
+      { text: `${cmd}: command not found. Type "help" for available commands.`, color: "red" },
+    ])
+  }
+}

--- a/src/components/retro/useRetroTerminal.ts
+++ b/src/components/retro/useRetroTerminal.ts
@@ -1,0 +1,122 @@
+import { useState, useCallback, useEffect, useRef } from "react"
+import { BOOT_LINES } from "./RetroAsciiArt"
+import { executeRetroCommand, type RetroLine, type RetroContext } from "./retro-commands"
+
+interface UseRetroTerminalProps {
+  onColorChange: (scheme: "green" | "amber") => void
+}
+
+interface UseRetroTerminalReturn {
+  lines: RetroLine[]
+  currentInput: string
+  setCurrentInput: (val: string) => void
+  handleKeyDown: (e: React.KeyboardEvent) => void
+  bootComplete: boolean
+}
+
+export function useRetroTerminal({ onColorChange }: UseRetroTerminalProps): UseRetroTerminalReturn {
+  const [lines, setLines] = useState<RetroLine[]>([])
+  const [currentInput, setCurrentInput] = useState("")
+  const [commandHistory, setCommandHistory] = useState<string[]>([])
+  const [historyIndex, setHistoryIndex] = useState(-1)
+  const [bootComplete, setBootComplete] = useState(false)
+  const bootRef = useRef(false)
+
+  // Boot sequence
+  useEffect(() => {
+    if (bootRef.current) return
+    bootRef.current = true
+
+    let i = 0
+    const timer = setInterval(() => {
+      if (i < BOOT_LINES.length) {
+        const line = BOOT_LINES[i]
+        setLines(prev => [...prev, { text: line, color: i < 2 ? "bright" : undefined }])
+        i++
+      } else {
+        clearInterval(timer)
+        setBootComplete(true)
+      }
+    }, 120)
+
+    return () => clearInterval(timer)
+  }, [])
+
+  const addLines = useCallback((newLines: RetroLine[]) => {
+    setLines(prev => [...prev, ...newLines])
+  }, [])
+
+  const clear = useCallback(() => {
+    setLines([])
+  }, [])
+
+  const ctx: RetroContext = {
+    addLines,
+    clear,
+    setColorScheme: onColorChange,
+  }
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault()
+      const input = currentInput.trim()
+
+      // Show the command in output
+      setLines(prev => [...prev, { text: `> ${currentInput}`, color: "bright" }])
+
+      if (input) {
+        setCommandHistory(prev => [...prev, input])
+        executeRetroCommand(input, ctx)
+      }
+
+      setCurrentInput("")
+      setHistoryIndex(-1)
+      return
+    }
+
+    if (e.key === "ArrowUp") {
+      e.preventDefault()
+      if (commandHistory.length === 0) return
+      const newIdx = historyIndex === -1 ? commandHistory.length - 1 : Math.max(0, historyIndex - 1)
+      setHistoryIndex(newIdx)
+      setCurrentInput(commandHistory[newIdx])
+      return
+    }
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      if (historyIndex === -1) return
+      if (historyIndex >= commandHistory.length - 1) {
+        setHistoryIndex(-1)
+        setCurrentInput("")
+      } else {
+        const newIdx = historyIndex + 1
+        setHistoryIndex(newIdx)
+        setCurrentInput(commandHistory[newIdx])
+      }
+      return
+    }
+
+    if (e.ctrlKey && e.key === "l") {
+      e.preventDefault()
+      clear()
+      return
+    }
+
+    if (e.ctrlKey && e.key === "c") {
+      e.preventDefault()
+      setLines(prev => [...prev, { text: `> ${currentInput}^C`, color: "dim" }])
+      setCurrentInput("")
+      return
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentInput, commandHistory, historyIndex])
+
+  return {
+    lines,
+    currentInput,
+    setCurrentInput,
+    handleKeyDown,
+    bootComplete,
+  }
+}

--- a/src/components/shared/ModeSwitcher.tsx
+++ b/src/components/shared/ModeSwitcher.tsx
@@ -2,10 +2,16 @@ import { motion } from "framer-motion"
 import { LayoutGrid } from "lucide-react"
 import { useMode } from "@/context/mode-context"
 
+const MODE_STYLES: Record<string, string> = {
+  techie: "fixed bottom-3 left-3 z-50 flex items-center gap-2 px-3 py-1.5 font-mono text-xs border border-[#3c3c3c] bg-[#1e1e1e] text-[#608b4e] hover:bg-[#2d2d2d] hover:text-[#b5cea8] transition-colors",
+  retro: "fixed bottom-3 left-3 z-50 flex items-center gap-2 px-3 py-1.5 font-mono text-xs border border-green-800 bg-black text-green-400 hover:bg-green-950 hover:text-green-300 transition-colors",
+  dashboard: "fixed bottom-3 left-3 z-50 flex items-center gap-2 px-3 py-1.5 text-xs border border-[#2a2a34] bg-[#1a1a24] text-[#00D4FF] hover:bg-[#2a2a34] hover:text-white transition-colors rounded",
+}
+
+const DEFAULT_STYLE = "fixed bottom-6 left-6 z-50 flex items-center gap-2 px-4 py-2 rounded-full border border-border/50 bg-background/80 backdrop-blur-sm text-muted-foreground hover:text-foreground hover:border-border transition-colors text-sm shadow-lg"
+
 export function ModeSwitcher() {
   const { mode, clearMode } = useMode()
-
-  const isTechie = mode === 'techie'
 
   return (
     <motion.button
@@ -14,11 +20,7 @@ export function ModeSwitcher() {
       transition={{ delay: 0.5 }}
       onClick={clearMode}
       title="Switch view mode"
-      className={
-        isTechie
-          ? "fixed bottom-3 left-3 z-50 flex items-center gap-2 px-3 py-1.5 font-mono text-xs border border-[#3c3c3c] bg-[#1e1e1e] text-[#608b4e] hover:bg-[#2d2d2d] hover:text-[#b5cea8] transition-colors"
-          : "fixed bottom-6 left-6 z-50 flex items-center gap-2 px-4 py-2 rounded-full border border-border/50 bg-background/80 backdrop-blur-sm text-muted-foreground hover:text-foreground hover:border-border transition-colors text-sm shadow-lg"
-      }
+      className={MODE_STYLES[mode ?? ''] ?? DEFAULT_STYLE}
     >
       <LayoutGrid className="h-4 w-4" />
       <span className="hidden sm:inline">Switch Mode</span>

--- a/src/context/mode-context.tsx
+++ b/src/context/mode-context.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
 
-export type PortfolioMode = 'business-card' | 'resume' | 'creative' | 'techie'
+export type PortfolioMode = 'business-card' | 'resume' | 'creative' | 'techie' | 'retro' | 'dashboard'
 
 const STORAGE_KEY = 'portfolio-mode'
 
@@ -13,13 +13,14 @@ interface ModeContextType {
 
 const ModeContext = createContext<ModeContextType | null>(null)
 
+const VALID_MODES = new Set<PortfolioMode>([
+  'business-card', 'resume', 'creative', 'techie', 'retro', 'dashboard'
+])
+
 function getStoredMode(): PortfolioMode | null {
   if (typeof window === 'undefined') return null
   const stored = localStorage.getItem(STORAGE_KEY)
-  if (stored === 'business-card' || stored === 'resume' || stored === 'creative' || stored === 'techie') {
-    return stored
-  }
-  return null
+  return VALID_MODES.has(stored as PortfolioMode) ? (stored as PortfolioMode) : null
 }
 
 interface ModeProviderProps {

--- a/src/index.css
+++ b/src/index.css
@@ -300,6 +300,50 @@
   background-color: #003300 !important;
 }
 
+/* Retro CRT effects */
+.retro-scanlines {
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 1px,
+    rgba(0, 0, 0, 0.12) 1px,
+    rgba(0, 0, 0, 0.12) 2px
+  );
+  pointer-events: none;
+}
+
+.retro-crt-screen {
+  border-radius: 16px;
+}
+
+@keyframes retro-flicker {
+  0%, 19.9%, 22%, 62.9%, 64%, 64.9%, 70%, 100% {
+    opacity: 1;
+  }
+  20%, 21.9%, 63%, 63.9%, 65%, 69.9% {
+    opacity: 0.97;
+  }
+}
+
+@keyframes retro-glow {
+  0% { text-shadow: 0 0 2px currentColor; }
+  50% { text-shadow: 0 0 6px currentColor, 0 0 12px currentColor; }
+  100% { text-shadow: 0 0 2px currentColor; }
+}
+
+.retro-text-glow {
+  animation: retro-glow 4s ease-in-out infinite;
+}
+
+@keyframes retro-cursor-blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+.retro-cursor {
+  animation: retro-cursor-blink 1s step-end infinite;
+}
+
 /* Print styles for resume */
 @media print {
   body {

--- a/src/pages/Gateway.tsx
+++ b/src/pages/Gateway.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion"
-import { CreditCard, FileText, Sparkles, Terminal } from "lucide-react"
+import { CreditCard, FileText, Sparkles, Terminal, Monitor, BarChart3 } from "lucide-react"
 import { useMode, type PortfolioMode } from "@/context/mode-context"
 
 const modes: { key: PortfolioMode; title: string; description: string; icon: typeof CreditCard; accent: string; bg: string; preview: string }[] = [
@@ -39,6 +39,24 @@ const modes: { key: PortfolioMode; title: string; description: string; icon: typ
     bg: "hover:border-green-400/50",
     preview: "Terminal & hacker vibes",
   },
+  {
+    key: "retro",
+    title: "Retro Terminal",
+    description: "Vintage computing — green phosphor CRT with command-line navigation.",
+    icon: Monitor,
+    accent: "from-lime-400 to-green-600",
+    bg: "hover:border-lime-400/50",
+    preview: "1980s hacker vibes",
+  },
+  {
+    key: "dashboard",
+    title: "Dashboard",
+    description: "Career analytics — skills radar, project metrics, and data visualizations.",
+    icon: BarChart3,
+    accent: "from-orange-400 to-red-500",
+    bg: "hover:border-orange-400/50",
+    preview: "Data-driven & analytical",
+  },
 ]
 
 const containerVariants = {
@@ -77,7 +95,7 @@ export function Gateway() {
         variants={containerVariants}
         initial="hidden"
         animate="visible"
-        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 max-w-5xl w-full"
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl w-full"
       >
         {modes.map((m) => (
           <motion.button

--- a/src/pages/RetroTerminalPage.tsx
+++ b/src/pages/RetroTerminalPage.tsx
@@ -1,0 +1,17 @@
+import { useState } from "react"
+import { CRTFrame } from "@/components/retro/CRTFrame"
+import { RetroTerminal } from "@/components/retro/RetroTerminal"
+import { ModeSwitcher } from "@/components/shared/ModeSwitcher"
+
+export function RetroTerminalPage() {
+  const [colorScheme, setColorScheme] = useState<"green" | "amber">("green")
+
+  return (
+    <>
+      <CRTFrame colorScheme={colorScheme}>
+        <RetroTerminal colorScheme={colorScheme} onColorChange={setColorScheme} />
+      </CRTFrame>
+      <ModeSwitcher />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- New **Retro Terminal** mode: 1980s CRT monitor with green phosphor display, scanlines, screen glow, and vignette
- Full command-line interface with 15+ commands (help, whoami, skills, experience, projects, contact, fortune, etc.)
- Green/amber color scheme toggle via `color` command
- Easter eggs: `sudo hire daniel`, `rm -rf /`, `vim`
- Boot sequence animation on load
- Mode system expanded to 6 modes (business-card, resume, creative, techie, retro, dashboard)
- Gateway grid updated from 4-col to 3x2 for 6 cards
- AppRoutes refactored from if-chain to lookup table
- ModeSwitcher refactored to lookup table for mode-specific styles

## Test plan
- [ ] Gateway shows 6 mode cards in 3x2 grid
- [ ] Click "Retro Terminal" → CRT boot sequence plays with typewriter effect
- [ ] Type `help` → command list displays
- [ ] Type `skills` → skills data renders in ASCII table
- [ ] Type `experience` → career history renders
- [ ] Type `color amber` → screen changes to amber phosphor
- [ ] Type `sudo hire daniel` → easter egg response
- [ ] Arrow keys navigate command history
- [ ] Ctrl+L clears screen
- [ ] Mobile: responsive CRT frame, full-width terminal
- [ ] `npm run build` passes