### PR TITLE
feat: add Calendar booking mode (Calendly-style)

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -7,6 +7,7 @@ import { ResumePage } from "@/pages/ResumePage"
 import { TechieLayout } from "@/components/techie/TechieLayout"
 import { RetroTerminalPage } from "@/pages/RetroTerminalPage"
 import { DashboardPage } from "@/pages/DashboardPage"
+import { CalendarPage } from "@/pages/CalendarPage"
 
 import { Hero } from "@/components/sections/Hero"
 import { About } from "@/components/sections/About"
@@ -92,6 +93,7 @@ const MODE_PAGES: Partial<Record<PortfolioMode, React.ReactElement>> = {
   "techie": <TechieLayout />,
   "retro": <RetroTerminalPage />,
   "dashboard": <DashboardPage />,
+  "calendar": <CalendarPage />,
 }
 
 export function AppRoutes() {

--- a/src/components/calendar/BookingForm.tsx
+++ b/src/components/calendar/BookingForm.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import * as z from 'zod'
+import { ArrowLeft, Calendar, Clock, Globe, Loader2, Send } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import type { MeetingType, BookingFormData } from '@/data/calendar'
+import { formatDateShort } from '@/data/calendar'
+
+const bookingSchema = z.object({
+  name: z.string().min(2, 'Name must be at least 2 characters'),
+  email: z.string().email('Please enter a valid email'),
+  message: z.string().optional(),
+})
+
+interface BookingFormProps {
+  meeting: MeetingType
+  date: Date
+  timeLabel: string
+  timezone: string
+  onSubmit: (data: BookingFormData) => void
+  onBack: () => void
+}
+
+export function BookingForm({ meeting, date, timeLabel, timezone, onSubmit, onBack }: BookingFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<BookingFormData>({
+    resolver: zodResolver(bookingSchema),
+  })
+
+  async function handleFormSubmit(data: BookingFormData) {
+    setIsSubmitting(true)
+    // Simulate API call
+    await new Promise((resolve) => setTimeout(resolve, 1500))
+    onSubmit(data)
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: 20 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -20 }}
+      transition={{ duration: 0.3 }}
+    >
+      {/* Back button */}
+      <div className="flex items-center gap-3 mb-6">
+        <button
+          onClick={onBack}
+          className="p-1.5 rounded-lg text-[#6b8a8e] hover:text-teal-400 hover:bg-[#111a1e] transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+        </button>
+        <h3 className="text-lg font-semibold text-white">Confirm Booking</h3>
+      </div>
+
+      {/* Summary */}
+      <div className="p-4 rounded-xl bg-[#111a1e] border border-[#1a2e32] mb-6">
+        <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+          <div className="flex items-center gap-2 text-white">
+            <Calendar className="w-4 h-4 text-teal-400" />
+            <span>{formatDateShort(date)}</span>
+          </div>
+          <div className="flex items-center gap-2 text-white">
+            <Clock className="w-4 h-4 text-teal-400" />
+            <span>{timeLabel} ({meeting.duration} min)</span>
+          </div>
+          <div className="flex items-center gap-2 text-[#6b8a8e]">
+            <Globe className="w-3.5 h-3.5" />
+            <span className="text-xs">{timezone}</span>
+          </div>
+        </div>
+        <p className="text-xs text-[#6b8a8e] mt-2">{meeting.title}</p>
+      </div>
+
+      {/* Form */}
+      <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="booking-name" className="text-[#8a9a9e]">Name</Label>
+            <Input
+              id="booking-name"
+              placeholder="Your name"
+              {...register('name')}
+              className={`bg-[#111a1e] border-[#1a2e32] text-white placeholder:text-[#3a4a4e] focus:border-teal-700 ${errors.name ? 'border-red-500' : ''}`}
+            />
+            {errors.name && <p className="text-xs text-red-400">{errors.name.message}</p>}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="booking-email" className="text-[#8a9a9e]">Email</Label>
+            <Input
+              id="booking-email"
+              type="email"
+              placeholder="your@email.com"
+              {...register('email')}
+              className={`bg-[#111a1e] border-[#1a2e32] text-white placeholder:text-[#3a4a4e] focus:border-teal-700 ${errors.email ? 'border-red-500' : ''}`}
+            />
+            {errors.email && <p className="text-xs text-red-400">{errors.email.message}</p>}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="booking-message" className="text-[#8a9a9e]">
+            Message <span className="text-[#3a4a4e]">(optional)</span>
+          </Label>
+          <Textarea
+            id="booking-message"
+            placeholder="Anything you'd like to discuss..."
+            {...register('message')}
+            className="bg-[#111a1e] border-[#1a2e32] text-white placeholder:text-[#3a4a4e] focus:border-teal-700 min-h-[80px]"
+          />
+        </div>
+
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full bg-teal-600 hover:bg-teal-500 text-white"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Booking...
+            </>
+          ) : (
+            <>
+              Confirm Booking <Send className="ml-2 h-4 w-4" />
+            </>
+          )}
+        </Button>
+      </form>
+    </motion.div>
+  )
+}

--- a/src/components/calendar/BookingSuccess.tsx
+++ b/src/components/calendar/BookingSuccess.tsx
@@ -1,0 +1,86 @@
+import { motion } from 'framer-motion'
+import { CheckCircle, Calendar, Clock, Globe, User, Mail } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { BookingConfirmation } from '@/data/calendar'
+import { formatDate } from '@/data/calendar'
+
+interface BookingSuccessProps {
+  booking: BookingConfirmation
+  onBookAnother: () => void
+}
+
+export function BookingSuccess({ booking, onBookAnother }: BookingSuccessProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.4 }}
+      className="flex flex-col items-center text-center"
+    >
+      {/* Animated checkmark */}
+      <motion.div
+        initial={{ scale: 0 }}
+        animate={{ scale: 1 }}
+        transition={{ delay: 0.2, type: 'spring', stiffness: 200, damping: 15 }}
+        className="w-16 h-16 rounded-full bg-teal-900/30 flex items-center justify-center mb-4"
+      >
+        <CheckCircle className="w-8 h-8 text-teal-400" />
+      </motion.div>
+
+      <h3 className="text-xl font-bold text-white mb-1">Meeting Booked!</h3>
+      <p className="text-sm text-[#6b8a8e] mb-6">
+        A confirmation would be sent to {booking.guestEmail}
+      </p>
+
+      {/* Booking details card */}
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.3 }}
+        className="w-full max-w-sm p-5 rounded-xl bg-[#111a1e] border border-[#1a2e32] text-left mb-6"
+      >
+        <div className="text-xs text-[#6b8a8e] mb-3 font-mono">{booking.id}</div>
+
+        <div className="space-y-3 text-sm">
+          <div className="flex items-center gap-3">
+            <Calendar className="w-4 h-4 text-teal-400 flex-shrink-0" />
+            <span className="text-white">{formatDate(new Date(booking.date))}</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <Clock className="w-4 h-4 text-teal-400 flex-shrink-0" />
+            <span className="text-white">
+              {booking.timeLabel} ({booking.meetingType.duration} min)
+            </span>
+          </div>
+          <div className="flex items-center gap-3">
+            <Globe className="w-3.5 h-3.5 text-[#6b8a8e] flex-shrink-0" />
+            <span className="text-[#6b8a8e]">{booking.timezone}</span>
+          </div>
+
+          <div className="border-t border-[#1a2e32] pt-3 mt-3">
+            <div className="flex items-center gap-3 mb-2">
+              <User className="w-4 h-4 text-teal-400 flex-shrink-0" />
+              <span className="text-white">{booking.guestName}</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <Mail className="w-4 h-4 text-teal-400 flex-shrink-0" />
+              <span className="text-white">{booking.guestEmail}</span>
+            </div>
+          </div>
+
+          <div className="text-xs text-[#6b8a8e] pt-1">
+            {booking.meetingType.title}
+          </div>
+        </div>
+      </motion.div>
+
+      <Button
+        onClick={onBookAnother}
+        variant="outline"
+        className="border-[#1a2e32] text-teal-400 hover:bg-teal-900/30 hover:border-teal-700/50"
+      >
+        Book Another Meeting
+      </Button>
+    </motion.div>
+  )
+}

--- a/src/components/calendar/CalendarDatePicker.tsx
+++ b/src/components/calendar/CalendarDatePicker.tsx
@@ -1,0 +1,217 @@
+import { useState, useMemo } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { ChevronLeft, ChevronRight, Globe, ArrowLeft, Clock } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  generateAvailableSlots,
+  getMonthGrid,
+  isWeekday,
+  isPast,
+  isSameDay,
+  isMonthInRange,
+  formatDate,
+  MONTH_NAMES,
+  DAY_HEADERS,
+  type MeetingType,
+  type TimeSlot,
+} from '@/data/calendar'
+
+interface CalendarDatePickerProps {
+  meeting: MeetingType
+  timezone: string
+  onTimeSelect: (date: Date, time: string, timeLabel: string) => void
+  onBack: () => void
+}
+
+export function CalendarDatePicker({ meeting, timezone, onTimeSelect, onBack }: CalendarDatePickerProps) {
+  const now = new Date()
+  const [viewYear, setViewYear] = useState(now.getFullYear())
+  const [viewMonth, setViewMonth] = useState(now.getMonth())
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null)
+
+  const grid = useMemo(() => getMonthGrid(viewYear, viewMonth), [viewYear, viewMonth])
+
+  const slots = useMemo<TimeSlot[]>(() => {
+    if (!selectedDate) return []
+    return generateAvailableSlots(selectedDate, meeting.duration, timezone)
+  }, [selectedDate, meeting.duration, timezone])
+
+  const availableSlots = useMemo(() => slots.filter(s => s.available), [slots])
+
+  const canGoBack = isMonthInRange(
+    viewMonth === 0 ? viewYear - 1 : viewYear,
+    viewMonth === 0 ? 11 : viewMonth - 1,
+  )
+  const canGoForward = isMonthInRange(
+    viewMonth === 11 ? viewYear + 1 : viewYear,
+    viewMonth === 11 ? 0 : viewMonth + 1,
+  )
+
+  function navigateMonth(direction: -1 | 1) {
+    const newMonth = viewMonth + direction
+    if (newMonth < 0) {
+      setViewMonth(11)
+      setViewYear(y => y - 1)
+    } else if (newMonth > 11) {
+      setViewMonth(0)
+      setViewYear(y => y + 1)
+    } else {
+      setViewMonth(newMonth)
+    }
+    setSelectedDate(null)
+  }
+
+  function handleDateClick(date: Date) {
+    if (isPast(date) || !isWeekday(date)) return
+    setSelectedDate(date)
+  }
+
+  function handleTimeClick(slot: TimeSlot) {
+    if (!selectedDate || !slot.available) return
+    const timeStr = `${slot.hour.toString().padStart(2, '0')}:${slot.minute.toString().padStart(2, '0')}`
+    onTimeSelect(selectedDate, timeStr, slot.label)
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: 20 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -20 }}
+      transition={{ duration: 0.3 }}
+    >
+      {/* Back button + meeting info */}
+      <div className="flex items-center gap-3 mb-6">
+        <button
+          onClick={onBack}
+          className="p-1.5 rounded-lg text-[#6b8a8e] hover:text-teal-400 hover:bg-[#111a1e] transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+        </button>
+        <div>
+          <h3 className="text-lg font-semibold text-white">{meeting.title}</h3>
+          <p className="text-xs text-[#6b8a8e]">
+            <Clock className="w-3 h-3 inline mr-1" />
+            {meeting.duration} min
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-col lg:flex-row gap-6">
+        {/* Calendar grid */}
+        <div className="flex-1 min-w-0">
+          {/* Month navigation */}
+          <div className="flex items-center justify-between mb-4">
+            <button
+              onClick={() => navigateMonth(-1)}
+              disabled={!canGoBack}
+              className="p-1.5 rounded-lg text-[#6b8a8e] hover:text-teal-400 hover:bg-[#111a1e] transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <span className="text-sm font-medium text-white">
+              {MONTH_NAMES[viewMonth]} {viewYear}
+            </span>
+            <button
+              onClick={() => navigateMonth(1)}
+              disabled={!canGoForward}
+              className="p-1.5 rounded-lg text-[#6b8a8e] hover:text-teal-400 hover:bg-[#111a1e] transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* Day headers */}
+          <div className="grid grid-cols-7 gap-1 mb-1">
+            {DAY_HEADERS.map((d) => (
+              <div key={d} className="text-center text-xs text-[#6b8a8e] py-1 font-medium">
+                {d}
+              </div>
+            ))}
+          </div>
+
+          {/* Date cells */}
+          <div className="grid grid-cols-7 gap-1">
+            {grid.map((date, i) => {
+              if (!date) {
+                return <div key={`empty-${i}`} className="aspect-square" />
+              }
+
+              const past = isPast(date)
+              const weekend = !isWeekday(date)
+              const disabled = past || weekend
+              const selected = selectedDate && isSameDay(date, selectedDate)
+
+              return (
+                <button
+                  key={date.toISOString()}
+                  onClick={() => handleDateClick(date)}
+                  disabled={disabled}
+                  className={`
+                    aspect-square flex items-center justify-center rounded-lg text-sm transition-colors
+                    ${disabled
+                      ? 'text-[#2a3a3e] cursor-not-allowed'
+                      : selected
+                        ? 'bg-teal-600 text-white font-medium'
+                        : 'text-white hover:bg-teal-900/40 cursor-pointer'
+                    }
+                  `}
+                >
+                  {date.getDate()}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Time slots */}
+        <div className="lg:w-48 flex-shrink-0">
+          <AnimatePresence mode="wait">
+            {selectedDate ? (
+              <motion.div
+                key={selectedDate.toISOString()}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                transition={{ duration: 0.2 }}
+              >
+                <p className="text-sm font-medium text-white mb-1">
+                  {formatDate(selectedDate)}
+                </p>
+                <div className="flex items-center gap-1 text-xs text-[#6b8a8e] mb-3">
+                  <Globe className="w-3 h-3" />
+                  <span>{timezone}</span>
+                </div>
+
+                {availableSlots.length === 0 ? (
+                  <p className="text-sm text-[#6b8a8e]">No available slots for this date.</p>
+                ) : (
+                  <div className="flex flex-col gap-1.5 max-h-[320px] overflow-y-auto pr-1">
+                    {availableSlots.map((slot) => (
+                      <Button
+                        key={`${slot.hour}-${slot.minute}`}
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleTimeClick(slot)}
+                        className="w-full text-xs border-[#1a2e32] text-teal-400 hover:bg-teal-900/30 hover:border-teal-700/50 hover:text-teal-300"
+                      >
+                        {slot.label}
+                      </Button>
+                    ))}
+                  </div>
+                )}
+              </motion.div>
+            ) : (
+              <motion.p
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                className="text-sm text-[#6b8a8e] lg:mt-8"
+              >
+                Select a date to see available times.
+              </motion.p>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </motion.div>
+  )
+}

--- a/src/components/calendar/CalendarProfile.tsx
+++ b/src/components/calendar/CalendarProfile.tsx
@@ -1,0 +1,48 @@
+import { motion } from 'framer-motion'
+import { Github, Linkedin, Mail } from 'lucide-react'
+
+const socials = [
+  { icon: Github, href: 'https://github.com/dmhernandez2525', label: 'GitHub' },
+  { icon: Linkedin, href: 'https://linkedin.com/in/dh25', label: 'LinkedIn' },
+  { icon: Mail, href: 'mailto:daniel@interestingandbeyond.com', label: 'Email' },
+]
+
+export function CalendarProfile() {
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -20 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.5 }}
+      className="flex flex-col items-center text-center lg:items-start lg:text-left"
+    >
+      <img
+        src="/photos/daniel-headshot.png"
+        alt="Daniel Hernandez"
+        className="w-24 h-24 rounded-full object-cover border-2 border-teal-700/50 shadow-lg mb-4"
+      />
+
+      <h2 className="text-xl font-bold text-white mb-1">Daniel Hernandez</h2>
+      <p className="text-sm text-teal-400 mb-3">Senior Software Engineer</p>
+
+      <p className="text-sm text-[#8a9a9e] leading-relaxed mb-6">
+        Building full-stack applications with React, TypeScript, and Python.
+        Let's chat about tech, projects, or opportunities.
+      </p>
+
+      <div className="flex gap-3">
+        {socials.map((s) => (
+          <a
+            key={s.label}
+            href={s.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={s.label}
+            className="p-2 rounded-lg border border-[#1a2e32] text-[#6b8a8e] hover:text-teal-400 hover:border-teal-700/50 transition-colors"
+          >
+            <s.icon className="w-4 h-4" />
+          </a>
+        ))}
+      </div>
+    </motion.div>
+  )
+}

--- a/src/components/calendar/MeetingTypeSelector.tsx
+++ b/src/components/calendar/MeetingTypeSelector.tsx
@@ -1,0 +1,70 @@
+import { motion } from 'framer-motion'
+import { Zap, Coffee, Code } from 'lucide-react'
+import type { MeetingType } from '@/data/calendar'
+
+const ICONS: Record<string, typeof Zap> = {
+  'quick-intro': Zap,
+  'coffee-chat': Coffee,
+  'technical-discussion': Code,
+}
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.1, delayChildren: 0.2 },
+  },
+}
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.4 } },
+}
+
+interface MeetingTypeSelectorProps {
+  meetingTypes: MeetingType[]
+  onSelect: (meeting: MeetingType) => void
+}
+
+export function MeetingTypeSelector({ meetingTypes, onSelect }: MeetingTypeSelectorProps) {
+  return (
+    <div>
+      <h3 className="text-lg font-semibold text-white mb-1">Select a Meeting Type</h3>
+      <p className="text-sm text-[#6b8a8e] mb-6">Choose the type of meeting you'd like to schedule.</p>
+
+      <motion.div
+        variants={containerVariants}
+        initial="hidden"
+        animate="visible"
+        className="flex flex-col gap-3"
+      >
+        {meetingTypes.map((meeting) => {
+          const Icon = ICONS[meeting.id] ?? Zap
+          return (
+            <motion.button
+              key={meeting.id}
+              variants={cardVariants}
+              whileHover={{ scale: 1.01 }}
+              whileTap={{ scale: 0.99 }}
+              onClick={() => onSelect(meeting)}
+              className="flex items-start gap-4 p-4 rounded-xl border border-[#1a2e32] bg-[#111a1e] hover:border-teal-700/60 transition-colors text-left cursor-pointer"
+            >
+              <div className="p-2.5 rounded-lg bg-teal-900/30 text-teal-400 flex-shrink-0">
+                <Icon className="w-5 h-5" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="font-medium text-white">{meeting.title}</span>
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-teal-900/40 text-teal-400">
+                    {meeting.duration} min
+                  </span>
+                </div>
+                <p className="text-sm text-[#6b8a8e]">{meeting.description}</p>
+              </div>
+            </motion.button>
+          )
+        })}
+      </motion.div>
+    </div>
+  )
+}

--- a/src/components/shared/ModeSwitcher.tsx
+++ b/src/components/shared/ModeSwitcher.tsx
@@ -6,6 +6,7 @@ const MODE_STYLES: Record<string, string> = {
   techie: "fixed bottom-3 left-3 z-50 flex items-center gap-2 px-3 py-1.5 font-mono text-xs border border-[#3c3c3c] bg-[#1e1e1e] text-[#608b4e] hover:bg-[#2d2d2d] hover:text-[#b5cea8] transition-colors",
   retro: "fixed bottom-3 left-3 z-50 flex items-center gap-2 px-3 py-1.5 font-mono text-xs border border-green-800 bg-black text-green-400 hover:bg-green-950 hover:text-green-300 transition-colors",
   dashboard: "fixed bottom-3 left-3 z-50 flex items-center gap-2 px-3 py-1.5 text-xs border border-[#2a2a34] bg-[#1a1a24] text-[#00D4FF] hover:bg-[#2a2a34] hover:text-white transition-colors rounded",
+  calendar: "fixed bottom-3 left-3 z-50 flex items-center gap-2 px-3 py-1.5 text-xs border border-teal-800/50 bg-[#0a1a1a] text-teal-400 hover:bg-[#0d2525] hover:text-teal-300 transition-colors rounded",
 }
 
 const DEFAULT_STYLE = "fixed bottom-6 left-6 z-50 flex items-center gap-2 px-4 py-2 rounded-full border border-border/50 bg-background/80 backdrop-blur-sm text-muted-foreground hover:text-foreground hover:border-border transition-colors text-sm shadow-lg"

--- a/src/context/mode-context.tsx
+++ b/src/context/mode-context.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
 
-export type PortfolioMode = 'business-card' | 'resume' | 'creative' | 'techie' | 'retro' | 'dashboard'
+export type PortfolioMode = 'business-card' | 'resume' | 'creative' | 'techie' | 'retro' | 'dashboard' | 'calendar'
 
 const STORAGE_KEY = 'portfolio-mode'
 
@@ -14,7 +14,7 @@ interface ModeContextType {
 const ModeContext = createContext<ModeContextType | null>(null)
 
 const VALID_MODES = new Set<PortfolioMode>([
-  'business-card', 'resume', 'creative', 'techie', 'retro', 'dashboard'
+  'business-card', 'resume', 'creative', 'techie', 'retro', 'dashboard', 'calendar'
 ])
 
 function getStoredMode(): PortfolioMode | null {

--- a/src/data/calendar.ts
+++ b/src/data/calendar.ts
@@ -1,0 +1,297 @@
+// ========================================
+// CALENDAR BOOKING - DATA & LOGIC
+// ========================================
+
+// ----------------------------------------
+// TYPES
+// ----------------------------------------
+
+export interface MeetingType {
+  id: string
+  title: string
+  duration: number // minutes
+  description: string
+  color: string // tailwind color name
+}
+
+export interface TimeSlot {
+  hour: number
+  minute: number
+  label: string // formatted for display in visitor timezone
+  available: boolean
+}
+
+export interface BookingFormData {
+  name: string
+  email: string
+  message?: string
+}
+
+export interface BookingConfirmation {
+  id: string
+  meetingType: MeetingType
+  date: string // ISO date "2026-02-10"
+  timeLabel: string // formatted time string
+  timezone: string
+  guestName: string
+  guestEmail: string
+}
+
+// ----------------------------------------
+// MEETING TYPES
+// ----------------------------------------
+
+export const meetingTypes: MeetingType[] = [
+  {
+    id: 'quick-intro',
+    title: 'Quick Intro',
+    duration: 15,
+    description: 'A brief introduction call. Great for initial connections and quick questions.',
+    color: 'teal',
+  },
+  {
+    id: 'coffee-chat',
+    title: 'Coffee Chat',
+    duration: 30,
+    description: 'Casual conversation about tech, projects, or career opportunities.',
+    color: 'cyan',
+  },
+  {
+    id: 'technical-discussion',
+    title: 'Technical Discussion',
+    duration: 60,
+    description: 'In-depth technical conversation. Architecture reviews, code walkthroughs, or consulting.',
+    color: 'blue',
+  },
+]
+
+// ----------------------------------------
+// CONSTANTS
+// ----------------------------------------
+
+const OWNER_TIMEZONE = 'America/Chicago'
+const WORK_START_HOUR = 9 // 9 AM CT
+const WORK_END_HOUR = 17 // 5 PM CT
+const SLOT_INTERVAL = 30 // minutes
+const MAX_MONTHS_AHEAD = 2
+
+// ----------------------------------------
+// HELPERS
+// ----------------------------------------
+
+function simpleHash(str: string): number {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash) + str.charCodeAt(i)
+    hash |= 0
+  }
+  return Math.abs(hash)
+}
+
+function isSlotBooked(dateStr: string, slotIndex: number): boolean {
+  const hash = simpleHash(`${dateStr}-slot-${slotIndex}`)
+  return hash % 100 < 25 // ~25% of slots appear booked
+}
+
+function padTwo(n: number): string {
+  return n.toString().padStart(2, '0')
+}
+
+/**
+ * Format a Date object's time in a specific timezone.
+ */
+function formatTimeInTimezone(date: Date, timezone: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: timezone,
+  }).format(date)
+}
+
+// ----------------------------------------
+// AVAILABILITY GENERATION
+// ----------------------------------------
+
+/**
+ * Generate available time slots for a given date.
+ * Slots are generated in the owner's timezone (CT) then displayed
+ * in the visitor's timezone.
+ */
+export function generateAvailableSlots(
+  date: Date,
+  meetingDuration: number,
+  visitorTimezone: string,
+): TimeSlot[] {
+  const dateStr = toDateString(date)
+  const slots: TimeSlot[] = []
+
+  // Latest start time: must finish by WORK_END_HOUR
+  const latestStartMinutes = WORK_END_HOUR * 60 - meetingDuration
+
+  let slotIndex = 0
+  for (let minutes = WORK_START_HOUR * 60; minutes <= latestStartMinutes; minutes += SLOT_INTERVAL) {
+    const hour = Math.floor(minutes / 60)
+    const minute = minutes % 60
+
+    // Create a Date in the owner's timezone for this slot
+    // We build an ISO string for the owner's local time, then parse it
+    const slotDateStr = `${dateStr}T${padTwo(hour)}:${padTwo(minute)}:00`
+    const slotDate = createDateInTimezone(slotDateStr, OWNER_TIMEZONE)
+
+    const available = !isSlotBooked(dateStr, slotIndex)
+    const label = formatTimeInTimezone(slotDate, visitorTimezone)
+
+    slots.push({
+      hour,
+      minute,
+      label,
+      available,
+    })
+
+    slotIndex++
+  }
+
+  return slots
+}
+
+/**
+ * Create a Date object that represents the given local time in a specific timezone.
+ */
+function createDateInTimezone(localDateTimeStr: string, timezone: string): Date {
+  // Get the UTC offset for this timezone at this approximate time
+  // by creating a temporary date and formatting it
+  const tempDate = new Date(localDateTimeStr + 'Z') // treat as UTC temporarily
+  const utcStr = tempDate.toLocaleString('en-US', { timeZone: 'UTC' })
+  const tzStr = tempDate.toLocaleString('en-US', { timeZone: timezone })
+
+  // Parse both strings to get the offset in ms
+  const utcMs = new Date(utcStr).getTime()
+  const tzMs = new Date(tzStr).getTime()
+  const offsetMs = utcMs - tzMs
+
+  return new Date(tempDate.getTime() + offsetMs)
+}
+
+// ----------------------------------------
+// CALENDAR HELPERS
+// ----------------------------------------
+
+export function toDateString(date: Date): string {
+  const y = date.getFullYear()
+  const m = padTwo(date.getMonth() + 1)
+  const d = padTwo(date.getDate())
+  return `${y}-${m}-${d}`
+}
+
+export function isWeekday(date: Date): boolean {
+  const day = date.getDay()
+  return day !== 0 && day !== 6
+}
+
+export function isToday(date: Date): boolean {
+  const now = new Date()
+  return toDateString(date) === toDateString(now)
+}
+
+export function isPast(date: Date): boolean {
+  const now = new Date()
+  now.setHours(0, 0, 0, 0)
+  const compare = new Date(date)
+  compare.setHours(0, 0, 0, 0)
+  return compare < now
+}
+
+export function isSameDay(a: Date, b: Date): boolean {
+  return toDateString(a) === toDateString(b)
+}
+
+/**
+ * Get the calendar grid for a given month.
+ * Returns an array of 42 cells (6 rows x 7 cols).
+ * null = padding cell from adjacent month.
+ */
+export function getMonthGrid(year: number, month: number): (Date | null)[] {
+  const firstDay = new Date(year, month, 1).getDay() // 0=Sun
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+
+  const grid: (Date | null)[] = []
+
+  // Leading padding
+  for (let i = 0; i < firstDay; i++) {
+    grid.push(null)
+  }
+
+  // Actual days
+  for (let d = 1; d <= daysInMonth; d++) {
+    grid.push(new Date(year, month, d))
+  }
+
+  // Trailing padding to fill 6 rows (42 cells)
+  while (grid.length < 42) {
+    grid.push(null)
+  }
+
+  return grid
+}
+
+/**
+ * Check if a month/year is within the allowed booking range.
+ */
+export function isMonthInRange(year: number, month: number): boolean {
+  const now = new Date()
+  const currentYear = now.getFullYear()
+  const currentMonth = now.getMonth()
+
+  const monthsDiff = (year - currentYear) * 12 + (month - currentMonth)
+  return monthsDiff >= 0 && monthsDiff <= MAX_MONTHS_AHEAD
+}
+
+/**
+ * Get the visitor's timezone.
+ */
+export function getVisitorTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone
+}
+
+/**
+ * Format a date for display.
+ */
+export function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date)
+}
+
+export function formatDateShort(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  }).format(date)
+}
+
+/**
+ * Generate a pseudo-random booking ID.
+ */
+export function generateBookingId(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+  let id = 'CAL-'
+  for (let i = 0; i < 6; i++) {
+    id += chars[Math.floor(Math.random() * chars.length)]
+  }
+  return id
+}
+
+/**
+ * Month names for the calendar header.
+ */
+export const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+]
+
+export const DAY_HEADERS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react'
-import { AnimatePresence } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
+import { Construction } from 'lucide-react'
 import { CalendarProfile } from '@/components/calendar/CalendarProfile'
 import { MeetingTypeSelector } from '@/components/calendar/MeetingTypeSelector'
 import { CalendarDatePicker } from '@/components/calendar/CalendarDatePicker'
@@ -73,6 +74,18 @@ export function CalendarPage() {
 
   return (
     <div className="min-h-screen bg-[#0a1214] text-white">
+      {/* Development banner */}
+      <motion.div
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="bg-amber-900/30 border-b border-amber-700/40 px-4 py-2.5 text-center"
+      >
+        <p className="text-sm text-amber-300 flex items-center justify-center gap-2">
+          <Construction className="w-4 h-4" />
+          Under Development — Booking is simulated and not yet connected to a real calendar.
+        </p>
+      </motion.div>
+
       <div className="max-w-4xl mx-auto px-4 py-8 sm:py-12">
         <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-8 lg:gap-12">
           {/* Profile sidebar */}

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -1,0 +1,129 @@
+import { useState, useMemo } from 'react'
+import { AnimatePresence } from 'framer-motion'
+import { CalendarProfile } from '@/components/calendar/CalendarProfile'
+import { MeetingTypeSelector } from '@/components/calendar/MeetingTypeSelector'
+import { CalendarDatePicker } from '@/components/calendar/CalendarDatePicker'
+import { BookingForm } from '@/components/calendar/BookingForm'
+import { BookingSuccess } from '@/components/calendar/BookingSuccess'
+import {
+  meetingTypes,
+  getVisitorTimezone,
+  generateBookingId,
+  toDateString,
+  type MeetingType,
+  type BookingFormData,
+  type BookingConfirmation,
+} from '@/data/calendar'
+
+type BookingStep = 'select-meeting' | 'select-date' | 'confirm-booking' | 'success'
+
+export function CalendarPage() {
+  const timezone = useMemo(getVisitorTimezone, [])
+
+  const [step, setStep] = useState<BookingStep>('select-meeting')
+  const [selectedMeeting, setSelectedMeeting] = useState<MeetingType | null>(null)
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null)
+  const [selectedTimeLabel, setSelectedTimeLabel] = useState('')
+  const [booking, setBooking] = useState<BookingConfirmation | null>(null)
+
+  function handleMeetingSelect(meeting: MeetingType) {
+    setSelectedMeeting(meeting)
+    setStep('select-date')
+  }
+
+  function handleTimeSelect(date: Date, _timeRaw: string, timeLabel: string) {
+    setSelectedDate(date)
+    setSelectedTimeLabel(timeLabel)
+    setStep('confirm-booking')
+  }
+
+  function handleBookingSubmit(data: BookingFormData) {
+    if (!selectedMeeting || !selectedDate) return
+
+    const confirmation: BookingConfirmation = {
+      id: generateBookingId(),
+      meetingType: selectedMeeting,
+      date: toDateString(selectedDate),
+      timeLabel: selectedTimeLabel,
+      timezone,
+      guestName: data.name,
+      guestEmail: data.email,
+    }
+
+    setBooking(confirmation)
+    setStep('success')
+  }
+
+  function handleBookAnother() {
+    setStep('select-meeting')
+    setSelectedMeeting(null)
+    setSelectedDate(null)
+    setSelectedTimeLabel('')
+    setBooking(null)
+  }
+
+  function handleBackToMeetings() {
+    setStep('select-meeting')
+    setSelectedMeeting(null)
+  }
+
+  function handleBackToDate() {
+    setStep('select-date')
+  }
+
+  return (
+    <div className="min-h-screen bg-[#0a1214] text-white">
+      <div className="max-w-4xl mx-auto px-4 py-8 sm:py-12">
+        <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-8 lg:gap-12">
+          {/* Profile sidebar */}
+          <div className="lg:border-r lg:border-[#1a2e32] lg:pr-8">
+            <CalendarProfile />
+          </div>
+
+          {/* Booking flow */}
+          <div className="min-w-0">
+            <AnimatePresence mode="wait">
+              {step === 'select-meeting' && (
+                <MeetingTypeSelector
+                  key="meeting-select"
+                  meetingTypes={meetingTypes}
+                  onSelect={handleMeetingSelect}
+                />
+              )}
+
+              {step === 'select-date' && selectedMeeting && (
+                <CalendarDatePicker
+                  key="date-pick"
+                  meeting={selectedMeeting}
+                  timezone={timezone}
+                  onTimeSelect={handleTimeSelect}
+                  onBack={handleBackToMeetings}
+                />
+              )}
+
+              {step === 'confirm-booking' && selectedMeeting && selectedDate && (
+                <BookingForm
+                  key="booking-form"
+                  meeting={selectedMeeting}
+                  date={selectedDate}
+                  timeLabel={selectedTimeLabel}
+                  timezone={timezone}
+                  onSubmit={handleBookingSubmit}
+                  onBack={handleBackToDate}
+                />
+              )}
+
+              {step === 'success' && booking && (
+                <BookingSuccess
+                  key="booking-success"
+                  booking={booking}
+                  onBookAnother={handleBookAnother}
+                />
+              )}
+            </AnimatePresence>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Gateway.tsx
+++ b/src/pages/Gateway.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion"
-import { CreditCard, FileText, Sparkles, Terminal, Monitor, BarChart3 } from "lucide-react"
+import { CreditCard, FileText, Sparkles, Terminal, Monitor, BarChart3, CalendarDays } from "lucide-react"
 import { useMode, type PortfolioMode } from "@/context/mode-context"
 
 const modes: { key: PortfolioMode; title: string; description: string; icon: typeof CreditCard; accent: string; bg: string; preview: string }[] = [
@@ -56,6 +56,15 @@ const modes: { key: PortfolioMode; title: string; description: string; icon: typ
     accent: "from-orange-400 to-red-500",
     bg: "hover:border-orange-400/50",
     preview: "Data-driven & analytical",
+  },
+  {
+    key: "calendar",
+    title: "Book a Meeting",
+    description: "Schedule time with me — coffee chats, technical discussions, or quick intros.",
+    icon: CalendarDays,
+    accent: "from-teal-400 to-cyan-500",
+    bg: "hover:border-teal-400/50",
+    preview: "Calendly-style booking",
   },
 ]
 

--- a/src/pages/Gateway.tsx
+++ b/src/pages/Gateway.tsx
@@ -64,7 +64,7 @@ const modes: { key: PortfolioMode; title: string; description: string; icon: typ
     icon: CalendarDays,
     accent: "from-teal-400 to-cyan-500",
     bg: "hover:border-teal-400/50",
-    preview: "Calendly-style booking",
+    preview: "Under development",
   },
 ]
 


### PR DESCRIPTION
## Summary
- Adds a 7th portfolio mode ("Book a Meeting") with a Calendly-style scheduling experience
- Profile sidebar with headshot, bio, and social links
- 3 meeting types: Quick Intro (15m), Coffee Chat (30m), Technical Discussion (60m)
- Interactive calendar with month navigation, timezone-aware time slots
- Booking form with react-hook-form + zod validation
- Success confirmation screen with generated booking ID
- Deterministic availability (seeded pseudo-random ensures same date shows same slots)
- Fully responsive (two-column desktop, single-column mobile)
- Teal/cyan accent theme consistent with other mode styles

## New Files
- `src/data/calendar.ts` — Types, meeting configs, availability generation, timezone logic
- `src/pages/CalendarPage.tsx` — Page orchestrator with 4-step state machine
- `src/components/calendar/CalendarProfile.tsx` — Profile sidebar
- `src/components/calendar/MeetingTypeSelector.tsx` — Meeting type cards (step 1)
- `src/components/calendar/CalendarDatePicker.tsx` — Calendar grid + time slots (step 2)
- `src/components/calendar/BookingForm.tsx` — Booking confirmation form (step 3)
- `src/components/calendar/BookingSuccess.tsx` — Success screen (step 4)

## Modified Files
- `src/context/mode-context.tsx` — Added 'calendar' to PortfolioMode type
- `src/AppRoutes.tsx` — Registered CalendarPage in MODE_PAGES
- `src/pages/Gateway.tsx` — Added calendar card to Gateway grid
- `src/components/shared/ModeSwitcher.tsx` — Added teal-themed calendar style

## Test plan
- [ ] Gateway shows 7 mode cards with teal calendar card
- [ ] Calendar mode renders profile sidebar + meeting selector
- [ ] Clicking a meeting type shows the calendar grid
- [ ] Selecting a weekday shows timezone-aware time slots
- [ ] Selecting a time opens the booking form with summary
- [ ] Form validates name and email, submits with loading state
- [ ] Success screen shows booking ID and confirmation details
- [ ] "Book Another" resets the entire flow
- [ ] ModeSwitcher button has teal styling in calendar mode
- [ ] Same date always shows same availability (deterministic)
- [ ] Mobile layout works (single column)
- [ ] `npm run build` passes