### PR TITLE
fix: add .npmrc for Render deploy peer-deps conflict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
- Adds `.npmrc` with `legacy-peer-deps=true` to fix Render deploy failure
- `eslint@10.0.0` has a peer dependency conflict with `eslint-plugin-react-hooks@7.0.1` (supports up to ESLint 9)
- ESLint is dev-only and does not affect the production build output

## Test plan
- [x] `npm ci` succeeds locally
- [x] `npm run build` passes
- [ ] Render deploy succeeds after merge