### PR TITLE
Fix Mafia Wars character class bonus values

### DIFF
--- a/src/components/game/mafia-wars/constants.ts
+++ b/src/components/game/mafia-wars/constants.ts
@@ -74,7 +74,7 @@ export const CHARACTER_CLASSES: ClassDefinition[] = [
     description: 'Aggressive and relentless. More energy regeneration and bonus job XP.',
     icon: '💀',
     bonuses: {
-      energyRegenBonus: 2,
+      energyRegenBonus: 5,
       staminaRegenBonus: 0,
       jobXpMultiplier: 1.2,
       propertyIncomeMultiplier: 1.0,
@@ -103,7 +103,7 @@ export const CHARACTER_CLASSES: ClassDefinition[] = [
     icon: '⚔️',
     bonuses: {
       energyRegenBonus: 0,
-      staminaRegenBonus: 2,
+      staminaRegenBonus: 3,
       jobXpMultiplier: 1.0,
       propertyIncomeMultiplier: 1.0,
       bankFeeReduction: 0,


### PR DESCRIPTION
## Summary
- Fixed Maniac class `energyRegenBonus` from 2 to 5 (per game design spec)
- Fixed Fearless class `staminaRegenBonus` from 2 to 3 (per game design spec)

## Test plan
- [ ] Verify Maniac class grants +5 energy regen per tick
- [ ] Verify Fearless class grants +3 stamina regen per tick
- [ ] Verify Mogul class bonuses unchanged