### PR TITLE
Phase 6: Integrate Pokemon RPG into portfolio

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -26,6 +26,7 @@ import { CookieClickerGame } from "@/components/game/cookie-clicker"
 import { ChessGame } from "@/components/game/ChessGame"
 import { AgarGame } from "@/components/game/agar"
 import { MafiaWarsGame } from "@/components/game/mafia-wars"
+import { PokemonGame } from "@/components/game/pokemon"
 import { Philosophy } from "@/pages/Philosophy"
 import { Inventions } from "@/pages/Inventions"
 import { Blog } from "@/pages/Blog"
@@ -70,6 +71,7 @@ function CreativeRoutes() {
         <Route path="/chess" element={<ChessGame />} />
         <Route path="/agar" element={<AgarGame />} />
         <Route path="/mafia-wars" element={<MafiaWarsGame />} />
+        <Route path="/pokemon" element={<PokemonGame />} />
         <Route path="*" element={<NotFound />} />
       </Route>
 

--- a/src/components/game/pokemon/index.tsx
+++ b/src/components/game/pokemon/index.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import type { GameVersion } from './engine/types';
 import GameSelector from './components/GameSelector';
 import PokemonCanvas from './components/PokemonCanvas';
+import './pokemon.css';
 
 export function PokemonGame() {
   const [screen, setScreen] = useState<'select' | 'playing'>('select');

--- a/src/components/game/pokemon/pokemon.css
+++ b/src/components/game/pokemon/pokemon.css
@@ -1,0 +1,187 @@
+/* ============================================================================
+   Pokemon RPG — Retro Pixel Art Styles
+   ============================================================================ */
+
+/* Pixel-perfect rendering for canvas */
+.pokemon-canvas {
+  image-rendering: pixelated;
+  image-rendering: -moz-crisp-edges;
+  image-rendering: crisp-edges;
+}
+
+/* Game container */
+.pokemon-game {
+  font-family: 'Courier New', 'Lucida Console', Monaco, monospace;
+  -webkit-font-smoothing: none;
+  -moz-osx-font-smoothing: unset;
+}
+
+/* Dialog box styling */
+.pokemon-dialog {
+  background: linear-gradient(180deg, #f8f8f8 0%, #e8e8e8 100%);
+  border: 3px solid #383838;
+  border-radius: 8px;
+  box-shadow:
+    inset 0 0 0 2px #f8f8f8,
+    inset 0 0 0 4px #a8a8a8,
+    4px 4px 0 rgba(0, 0, 0, 0.3);
+  padding: 12px 16px;
+  color: #383838;
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.5px;
+}
+
+/* Menu styling */
+.pokemon-menu {
+  background: linear-gradient(180deg, #f8f8f8 0%, #e0e0e0 100%);
+  border: 3px solid #383838;
+  border-radius: 8px;
+  box-shadow:
+    inset 0 0 0 2px #f8f8f8,
+    inset 0 0 0 4px #a8a8a8,
+    4px 4px 0 rgba(0, 0, 0, 0.3);
+}
+
+.pokemon-menu-item {
+  padding: 6px 24px 6px 16px;
+  cursor: pointer;
+  color: #383838;
+  font-size: 14px;
+  transition: background-color 0.1s;
+}
+
+.pokemon-menu-item:hover,
+.pokemon-menu-item.selected {
+  background-color: rgba(56, 56, 56, 0.1);
+}
+
+.pokemon-menu-item.selected::before {
+  content: '▶';
+  position: absolute;
+  left: 8px;
+  font-size: 10px;
+}
+
+/* HP bar colors */
+.hp-bar-green { background: #48d048; }
+.hp-bar-yellow { background: #f8d030; }
+.hp-bar-red { background: #f85848; }
+
+/* Battle UI */
+.pokemon-battle-panel {
+  background: linear-gradient(180deg, #e8e8e8 0%, #d0d0d0 100%);
+  border: 3px solid #383838;
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 2px #f8f8f8;
+}
+
+/* Type badge colors */
+.type-normal { background: #a8a878; }
+.type-fire { background: #f08030; }
+.type-water { background: #6890f0; }
+.type-grass { background: #78c850; }
+.type-electric { background: #f8d030; }
+.type-ice { background: #98d8d8; }
+.type-fighting { background: #c03028; }
+.type-poison { background: #a040a0; }
+.type-ground { background: #e0c068; }
+.type-flying { background: #a890f0; }
+.type-psychic { background: #f85888; }
+.type-bug { background: #a8b820; }
+.type-rock { background: #b8a038; }
+.type-ghost { background: #705898; }
+.type-dragon { background: #7038f8; }
+.type-dark { background: #705848; }
+.type-steel { background: #b8b8d0; }
+.type-fairy { background: #ee99ac; }
+
+/* Scanline effect (optional, subtle) */
+.pokemon-scanlines::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.03) 2px,
+    rgba(0, 0, 0, 0.03) 4px
+  );
+  pointer-events: none;
+}
+
+/* Cursor blink animation for dialog */
+@keyframes pokemon-cursor-blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+.pokemon-cursor {
+  animation: pokemon-cursor-blink 0.8s infinite;
+}
+
+/* Screen transition */
+@keyframes pokemon-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.pokemon-fade-in {
+  animation: pokemon-fade-in 0.3s ease-out;
+}
+
+/* Battle intro swirl */
+@keyframes pokemon-swirl {
+  0% { clip-path: circle(100% at 50% 50%); }
+  100% { clip-path: circle(0% at 50% 50%); }
+}
+
+/* Mobile controls */
+.pokemon-dpad {
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.pokemon-dpad button {
+  background: rgba(60, 60, 60, 0.8);
+  border: 2px solid rgba(100, 100, 100, 0.6);
+  border-radius: 4px;
+  color: white;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.1s;
+}
+
+.pokemon-dpad button:active {
+  background: rgba(100, 100, 100, 0.9);
+  transform: scale(0.95);
+}
+
+.pokemon-action-btn {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  font-weight: bold;
+  font-size: 14px;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.pokemon-action-btn.btn-a {
+  background: rgba(220, 50, 50, 0.8);
+  border: 2px solid rgba(255, 80, 80, 0.6);
+}
+
+.pokemon-action-btn.btn-b {
+  background: rgba(50, 50, 220, 0.8);
+  border: 2px solid rgba(80, 80, 255, 0.6);
+}
+
+.pokemon-action-btn:active {
+  transform: scale(0.9);
+}

--- a/src/components/techie/TechieContentViewer.tsx
+++ b/src/components/techie/TechieContentViewer.tsx
@@ -14,6 +14,7 @@ const FallingBlocksGame = lazy(() => import("@/components/game/FallingBlocksGame
 const CookieClickerGame = lazy(() => import("@/components/game/cookie-clicker").then(m => ({ default: m.CookieClickerGame })))
 const AgarGame = lazy(() => import("@/components/game/agar").then(m => ({ default: m.AgarGame })))
 const MafiaWars = lazy(() => import("@/components/game/mafia-wars"))
+const PokemonGame = lazy(() => import("@/components/game/pokemon").then(m => ({ default: m.PokemonGame })))
 
 interface TechieContentViewerProps {
   tab: TechieTab | null
@@ -374,6 +375,7 @@ export function TechieContentViewer({ tab, onEditorChange, onRunCode, editorSett
     "game-cookie-clicker": <GameLoader><CookieClickerGame /></GameLoader>,
     "game-agar": <GameLoader><AgarGame /></GameLoader>,
     "game-mafia-wars": <GameLoader><MafiaWars /></GameLoader>,
+    "game-pokemon": <GameLoader><PokemonGame /></GameLoader>,
   }
 
   if (contentKey in gameMap) return <>{gameMap[contentKey]}</>

--- a/src/components/techie/techie-data.ts
+++ b/src/components/techie/techie-data.ts
@@ -33,6 +33,7 @@ export const fileTree: FileNode[] = [
           { name: "cookie-clicker.exe", type: "file", contentKey: "game-cookie-clicker" },
           { name: "agar.exe", type: "file", contentKey: "game-agar" },
           { name: "mafia-wars.exe", type: "file", contentKey: "game-mafia-wars" },
+          { name: "pokemon.exe", type: "file", contentKey: "game-pokemon" },
         ],
       },
       { name: ".env", type: "file", contentKey: "hidden-env", hidden: true },

--- a/src/components/techie/terminal/terminal-autocomplete.ts
+++ b/src/components/techie/terminal/terminal-autocomplete.ts
@@ -31,7 +31,7 @@ export function getCompletions(
 
   // run command: complete with game names
   if (cmdName === "run") {
-    const gameNames = ["snake", "tetris", "chess", "falling-blocks", "cookie-clicker", "agar", "mafia-wars"]
+    const gameNames = ["snake", "tetris", "chess", "falling-blocks", "cookie-clicker", "agar", "mafia-wars", "pokemon"]
     const partial = parts[parts.length - 1].toLowerCase()
     return gameNames
       .filter((g) => g.startsWith(partial) && g !== partial)

--- a/src/components/techie/terminal/terminal-commands.ts
+++ b/src/components/techie/terminal/terminal-commands.ts
@@ -202,6 +202,7 @@ const run: CommandHandler = (args, ctx) => {
     "cookie-clicker": { contentKey: "game-cookie-clicker", fileName: "cookie-clicker.exe" },
     agar: { contentKey: "game-agar", fileName: "agar.exe" },
     "mafia-wars": { contentKey: "game-mafia-wars", fileName: "mafia-wars.exe" },
+    pokemon: { contentKey: "game-pokemon", fileName: "pokemon.exe" },
   }
 
   const game = gameKeys[gameName]
@@ -341,7 +342,7 @@ const man: CommandHandler = (args, ctx) => {
       "",
       "DESCRIPTION:",
       "  Launches a game executable.",
-      "  Available: snake, tetris, chess, falling-blocks, cookie-clicker, agar, mafia-wars",
+      "  Available: snake, tetris, chess, falling-blocks, cookie-clicker, agar, mafia-wars, pokemon",
     ],
     js: [
       "JS(1) — run JavaScript code",

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -140,6 +140,20 @@ const games: Game[] = [
     yearPlayed: "2008-2010",
     funFact: "I spent way too many hours on the original. 'Just one more job' they said...",
     features: ["24 unique jobs across 6 tiers", "AI combat system", "8 property types for passive income", "24 weapons/armor/vehicles", "Skill point allocation", "Auto-save with localStorage"]
+  },
+  {
+    id: "pokemon",
+    title: "Pokemon RPG",
+    description: "A full Pokemon RPG recreation with battles, catching, and exploration!",
+    longDescription: "My pixel-art recreation of the classic Pokemon games. Explore the Kanto region, catch all 151 Pokemon, battle 8 Gym Leaders, defeat the Elite Four, and become the Champion! Features the complete battle system with type effectiveness, status conditions, and trainer AI.",
+    thumbnail: "/game-pokemon.svg",
+    category: "strategy",
+    link: "/pokemon",
+    isExternal: false,
+    isBuiltIn: true,
+    yearPlayed: "1996-2003",
+    funFact: "I started with Pokemon Red and a Charmander. Brock was brutal without a water type.",
+    features: ["151 Pokemon with accurate stats", "Full battle system with type chart", "8 Gym Leaders + Elite Four", "Wild encounters and catching", "Save/Load system", "Mobile touch controls"]
   }
 ]
 
@@ -257,6 +271,11 @@ export function Games() {
                     <Play className="w-3 h-3" /> Agar.io
                   </Button>
                 </Link>
+                <Link to="/pokemon">
+                  <Button size="sm" variant="secondary" className="gap-1">
+                    <Play className="w-3 h-3" /> Pokemon
+                  </Button>
+                </Link>
               </div>
             </motion.div>
           )}
@@ -301,6 +320,8 @@ export function Games() {
                     {game.id === "falling-blocks" && "🎮"}
                     {game.id === "tetris" && "🧱"}
                     {game.id === "snake" && "🐍"}
+                    {game.id === "mafia-wars" && "🔫"}
+                    {game.id === "pokemon" && "⚡"}
                   </div>
                   {game.isExternal && (
                     <div className="absolute bottom-2 right-2 text-xs text-muted-foreground bg-black/50 px-2 py-1 rounded">


### PR DESCRIPTION
## Summary
- Add `/pokemon` route accessible from creative mode
- Add game entry to Games page gallery with quick-play button
- Add `run pokemon` terminal command in techie mode
- Add retro pixel-art CSS styling (dialog boxes, type badges, HP bars, mobile controls)

## Test plan
- [x] Build passes with no errors
- [x] `/pokemon` route loads the game selector
- [x] Game appears in Games page gallery
- [x] `run pokemon` works in techie terminal
- [x] Pokemon CSS styles load correctly