### PR TITLE
Fix duplicate form IDs and terminal input

### DIFF
--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -187,9 +187,9 @@ export function Contact() {
                         <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                                 <div className="space-y-2">
-                                    <Label htmlFor="name">Name</Label>
+                                    <Label htmlFor="contact-name">Name</Label>
                                     <Input
-                                        id="name"
+                                        id="contact-name"
                                         placeholder="Your name"
                                         {...register("name")}
                                         className={errors.name ? "border-red-500" : ""}
@@ -197,9 +197,9 @@ export function Contact() {
                                     {errors.name && <p className="text-sm text-red-500">{errors.name.message}</p>}
                                 </div>
                                 <div className="space-y-2">
-                                    <Label htmlFor="email">Email</Label>
+                                    <Label htmlFor="contact-email">Email</Label>
                                     <Input
-                                        id="email"
+                                        id="contact-email"
                                         type="email"
                                         placeholder="your@email.com"
                                         {...register("email")}
@@ -208,11 +208,11 @@ export function Contact() {
                                     {errors.email && <p className="text-sm text-red-500">{errors.email.message}</p>}
                                 </div>
                             </div>
-                            
+
                             <div className="space-y-2">
-                                <Label htmlFor="message">Message</Label>
+                                <Label htmlFor="contact-message">Message</Label>
                                 <Textarea
-                                    id="message"
+                                    id="contact-message"
                                     placeholder="Tell me about your project, opportunity, or just say hi..."
                                     className={`min-h-[150px] ${errors.message ? "border-red-500" : ""}`}
                                     {...register("message")}

--- a/src/components/techie/terminal/TechieTerminal.tsx
+++ b/src/components/techie/terminal/TechieTerminal.tsx
@@ -64,10 +64,14 @@ export function TechieTerminal({
 
   // Focus input on mount and when clicking the terminal area
   useEffect(() => {
-    inputRef.current?.focus()
+    // Small delay to ensure DOM is ready and CodeMirror hasn't stolen focus
+    const timer = setTimeout(() => inputRef.current?.focus(), 50)
+    return () => clearTimeout(timer)
   }, [])
 
-  const handleContainerClick = () => {
+  const handleContainerClick = (e: React.MouseEvent) => {
+    // Prevent CodeMirror or other elements from recapturing focus
+    e.stopPropagation()
     inputRef.current?.focus()
   }
 

--- a/src/hooks/use-easter-eggs.ts
+++ b/src/hooks/use-easter-eggs.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef } from "react"
 
 interface UseEasterEggsProps {
     onKonami: () => void
@@ -9,40 +9,36 @@ interface UseEasterEggsProps {
 }
 
 export function useEasterEggs({ onKonami, onGandalf, onDaniel, onGhost, onMonkey }: UseEasterEggsProps) {
-    const [, setInputBuffer] = useState("")
+    const bufferRef = useRef("")
 
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             const key = e.key.toLowerCase()
-            
-            setInputBuffer(prev => {
-                const newBuffer = (prev + key).slice(-20) // Keep last 20 chars
 
-                // Konami Code (ArrowUp, etc maps to strings)
-                // Actually browsers return "ArrowUp", "a", "b"
-                // Let's use a separate tracker for konami or map keys?
-                // Simplified Konami: uuddlrlrba
-                
-                // Words
-                if (newBuffer.endsWith("gandalf")) {
-                    onGandalf()
-                    return ""
-                }
-                if (newBuffer.endsWith("daniel")) {
-                    onDaniel()
-                    return ""
-                }
-                if (newBuffer.endsWith("ghost")) {
-                    onGhost()
-                    return ""
-                }
-                if (newBuffer.endsWith("monkey") && onMonkey) {
-                    onMonkey()
-                    return ""
-                }
-                
-                return newBuffer
-            })
+            const newBuffer = (bufferRef.current + key).slice(-20) // Keep last 20 chars
+            bufferRef.current = newBuffer
+
+            // Words
+            if (newBuffer.endsWith("gandalf")) {
+                onGandalf()
+                bufferRef.current = ""
+                return
+            }
+            if (newBuffer.endsWith("daniel")) {
+                onDaniel()
+                bufferRef.current = ""
+                return
+            }
+            if (newBuffer.endsWith("ghost")) {
+                onGhost()
+                bufferRef.current = ""
+                return
+            }
+            if (newBuffer.endsWith("monkey") && onMonkey) {
+                onMonkey()
+                bufferRef.current = ""
+                return
+            }
         }
         
         // Konami specific listener for arrow keys

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -136,9 +136,9 @@ export function Login() {
 
           <form onSubmit={handleRealLogin} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
+              <Label htmlFor="login-email">Email</Label>
               <Input
-                id="email"
+                id="login-email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -148,9 +148,9 @@ export function Login() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
+              <Label htmlFor="login-password">Password</Label>
               <Input
-                id="password"
+                id="login-password"
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}


### PR DESCRIPTION
## Summary
- Fix console errors about duplicate form field IDs by prefixing Contact form IDs with `contact-` and Login form IDs with `login-`
- Fix terminal input not responding to keystrokes by switching useEasterEggs from useState to useRef (eliminates unnecessary re-renders on every keystroke)
- Add stopPropagation to terminal container click to prevent focus theft from CodeMirror editor
- Add delayed focus-on-mount for terminal input DOM readiness

## Test plan
- [x] Verify no console errors about duplicate IDs
- [x] Verify terminal input accepts keyboard input
- [x] Verify Contact form labels still focus correct inputs
- [x] Verify Login form labels still focus correct inputs
- [x] Verify easter egg sequences still trigger (type "daniel", "ghost", etc.)