### PR TITLE
Add Shopping Cart Hero game

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -27,6 +27,7 @@ import { ChessGame } from "@/components/game/ChessGame"
 import { AgarGame } from "@/components/game/agar"
 import { MafiaWarsGame } from "@/components/game/mafia-wars"
 import { PokemonGame } from "@/components/game/pokemon"
+import { ShoppingCartHeroGame } from "@/components/game/shopping-cart-hero"
 import { Philosophy } from "@/pages/Philosophy"
 import { Inventions } from "@/pages/Inventions"
 import { Blog } from "@/pages/Blog"
@@ -72,6 +73,7 @@ function CreativeRoutes() {
         <Route path="/agar" element={<AgarGame />} />
         <Route path="/mafia-wars" element={<MafiaWarsGame />} />
         <Route path="/pokemon" element={<PokemonGame />} />
+        <Route path="/shopping-cart-hero" element={<ShoppingCartHeroGame />} />
         <Route path="*" element={<NotFound />} />
       </Route>
 

--- a/src/components/game/shopping-cart-hero/constants.ts
+++ b/src/components/game/shopping-cart-hero/constants.ts
@@ -1,0 +1,154 @@
+// ============================================================================
+// Shopping Cart Hero — Game Constants & Upgrade Definitions
+// ============================================================================
+
+import type { UpgradeDef, PlayerUpgrades } from './types';
+
+// --- Canvas ---
+export const CANVAS_WIDTH = 800;
+export const CANVAS_HEIGHT = 500;
+
+// --- Hill geometry ---
+export const HILL_START_X = 50;
+export const HILL_START_Y = 80;
+export const HILL_END_X = 500;
+export const HILL_END_Y = 380;
+export const RAMP_WIDTH = 60;
+export const RAMP_HEIGHT = 40;
+export const RAMP_ANGLE = Math.PI / 4; // 45 degrees
+
+// --- Marker posts ---
+export const MARKER_1_X = 300;  // "jump into cart" marker
+export const MARKER_2_X = 460;  // ramp approach marker
+
+// --- Physics ---
+export const RUN_ACCELERATION = 0.3;
+export const MAX_RUN_SPEED = 14;
+export const GRAVITY = 0.38;
+export const AIR_DRAG = 0.9985;
+export const ROTATION_SPEED = 0.07;  // radians per frame
+export const BOUNCE_COEFFICIENT = 0.45;
+export const ROLL_FRICTION = 0.985;
+export const MIN_BOUNCE_VEL = 2;
+export const CRASH_ANGLE = Math.PI / 4;  // 45 degrees from level = crash
+
+// --- Launch ---
+export const LAUNCH_ANGLE = -Math.PI / 3.5; // ~51 degrees upward
+export const LAUNCH_SPEED_MULT = 1.6;        // speed multiplier at launch
+
+// --- Ground ---
+export const FLAT_GROUND_Y = HILL_END_Y + 20;
+
+// --- Scoring ---
+export const DISTANCE_SCORE_DIVISOR = 10;
+export const HEIGHT_SCORE_DIVISOR = 5;
+export const FLIP_POINTS = 300;
+export const HANDSTAND_POINTS = 200;
+export const SUPERMAN_POINTS = 350;
+export const BACKFLIP_POINTS = 300;
+
+// --- Upgrades ---
+
+export const WHEEL_UPGRADES: UpgradeDef = {
+  category: 'wheels',
+  tiers: [
+    { name: 'Junk Wheels', cost: 0, description: 'Rusty and barely round' },
+    { name: 'Round Wheels', cost: 200, description: '1.3x roll distance' },
+    { name: 'Metal Wheels', cost: 800, description: '1.6x roll distance' },
+    { name: 'Racing Wheels', cost: 2500, description: '2.0x roll distance' },
+  ],
+};
+
+export const ROCKET_UPGRADES: UpgradeDef = {
+  category: 'rockets',
+  tiers: [
+    { name: 'No Rockets', cost: 0, description: 'Nothing but gravity' },
+    { name: 'Bottle Rocket', cost: 500, description: '30 frames of thrust' },
+    { name: 'Medium Rocket', cost: 1500, description: '50 frames of thrust' },
+    { name: 'Mega Rocket', cost: 5000, description: '80 frames of thrust' },
+  ],
+};
+
+export const ARMOR_UPGRADES: UpgradeDef = {
+  category: 'armor',
+  tiers: [
+    { name: 'No Protection', cost: 0, description: 'Hope for the best' },
+    { name: 'Padding', cost: 300, description: 'Survive steeper landings' },
+    { name: 'Helmet + Pads', cost: 1200, description: 'Much crash resistance' },
+    { name: 'Full Armor', cost: 4000, description: 'Nearly uncrashable' },
+  ],
+};
+
+export const TRICK_DEFS = [
+  { id: 'handstand' as const, name: 'Handstand', cost: 400, description: 'Hold DOWN mid-air: 200 pts', points: HANDSTAND_POINTS },
+  { id: 'superman' as const, name: 'Superman', cost: 1000, description: 'Hold UP mid-air: 350 pts', points: SUPERMAN_POINTS },
+  { id: 'backflip' as const, name: 'Backflip', cost: 600, description: 'Rotate backward: 300 pts', points: BACKFLIP_POINTS },
+];
+
+export const GROUPIE_COSTS = [1500, 3000, 6000];
+
+// --- Upgrade effect values ---
+
+export const WHEEL_MULTIPLIERS = [1.0, 1.3, 1.6, 2.0];
+
+export const ROCKET_CONFIGS = [
+  { frames: 0, force: 0 },
+  { frames: 30, force: 0.8 },
+  { frames: 50, force: 1.2 },
+  { frames: 80, force: 1.8 },
+];
+
+export const ARMOR_CRASH_ANGLES = [
+  Math.PI / 4,       // 45°
+  Math.PI / 3,       // 60°
+  (5 * Math.PI) / 12, // 75°
+  Math.PI / 2,       // 90° (basically no crash)
+];
+
+export const GROUPIE_MULTIPLIERS = [1, 2, 3, 4];
+
+// --- Default upgrades ---
+
+export const DEFAULT_UPGRADES: PlayerUpgrades = {
+  wheels: 0,
+  rockets: 0,
+  armor: 0,
+  handstand: false,
+  superman: false,
+  backflip: false,
+  groupies: 0,
+};
+
+// --- Colors ---
+
+export const COLORS = {
+  sky: '#87CEEB',
+  skyHorizon: '#d4eaf7',
+  ground: '#5a9e3e',
+  groundDark: '#4a8e2e',
+  dirt: '#8B7355',
+  hill: '#6aae4e',
+  hillDark: '#5a9e3e',
+  ramp: '#555555',
+  rampLight: '#777777',
+  marker: '#ff6600',
+  markerFlag: '#ff3300',
+  stickman: '#222222',
+  cart: '#888888',
+  cartDark: '#666666',
+  cartWheel: '#333333',
+  rocket: '#ff4444',
+  rocketFlame: '#ffaa00',
+  cloud: 'rgba(255, 255, 255, 0.8)',
+  building: '#aaaaaa',
+  buildingDark: '#888888',
+  window: '#66aacc',
+  crash: '#ff0000',
+  money: '#ffdd00',
+  text: '#ffffff',
+  textDark: '#000000',
+  ui: '#1a1a2e',
+  uiLight: '#16213e',
+  uiAccent: '#e94560',
+  uiButton: '#0f3460',
+};

--- a/src/components/game/shopping-cart-hero/constants.ts
+++ b/src/components/game/shopping-cart-hero/constants.ts
@@ -14,8 +14,6 @@ export const HILL_START_Y = 80;
 export const HILL_END_X = 500;
 export const HILL_END_Y = 380;
 export const RAMP_WIDTH = 60;
-export const RAMP_HEIGHT = 40;
-export const RAMP_ANGLE = Math.PI / 4; // 45 degrees
 
 // --- Marker posts ---
 export const MARKER_1_X = 300;  // "jump into cart" marker
@@ -30,8 +28,6 @@ export const ROTATION_SPEED = 0.07;  // radians per frame
 export const BOUNCE_COEFFICIENT = 0.45;
 export const ROLL_FRICTION = 0.985;
 export const MIN_BOUNCE_VEL = 2;
-export const CRASH_ANGLE = Math.PI / 4;  // 45 degrees from level = crash
-
 // --- Launch ---
 export const LAUNCH_ANGLE = -Math.PI / 3.5; // ~51 degrees upward
 export const LAUNCH_SPEED_MULT = 1.6;        // speed multiplier at launch

--- a/src/components/game/shopping-cart-hero/index.tsx
+++ b/src/components/game/shopping-cart-hero/index.tsx
@@ -1,0 +1,531 @@
+// ============================================================================
+// Shopping Cart Hero — Main Game Component
+// ============================================================================
+
+import { useRef, useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import type { GamePhase, GameState, InputKeys } from './types';
+import {
+  CANVAS_WIDTH, CANVAS_HEIGHT, DEFAULT_UPGRADES, FLAT_GROUND_Y,
+  HILL_END_X, RAMP_WIDTH, HILL_START_X,
+  WHEEL_UPGRADES, ROCKET_UPGRADES, ARMOR_UPGRADES,
+  TRICK_DEFS, GROUPIE_COSTS, GROUPIE_MULTIPLIERS,
+} from './constants';
+import {
+  createRunner, updateRunner, createCart, launchCart,
+  updateCartFlight, updateCartRolling, createTrickState, updateTricks,
+  getDistance, getHeight,
+} from './physics';
+import { render } from './renderer';
+import { calculateResult, purchaseUpgrade } from './shop';
+
+const SAVE_KEY = 'shopping-cart-hero-save';
+
+function loadSave(): { money: number; highScore: number; upgrades: typeof DEFAULT_UPGRADES; totalRuns: number } {
+  try {
+    const raw = localStorage.getItem(SAVE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch { /* ignore */ }
+  return { money: 0, highScore: 0, upgrades: { ...DEFAULT_UPGRADES }, totalRuns: 0 };
+}
+
+function saveToDisk(money: number, highScore: number, upgrades: typeof DEFAULT_UPGRADES, totalRuns: number) {
+  localStorage.setItem(SAVE_KEY, JSON.stringify({ money, highScore, upgrades, totalRuns }));
+}
+
+export function ShoppingCartHeroGame() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const keysRef = useRef<InputKeys>({ left: false, right: false, up: false, down: false });
+  const stateRef = useRef<GameState | null>(null);
+  const frameRef = useRef(0);
+  const animRef = useRef<number>(0);
+  const maxHeightRef = useRef(0);
+
+  const [phase, setPhase] = useState<GamePhase>('menu');
+  const [money, setMoney] = useState(() => loadSave().money);
+  const [highScore, setHighScore] = useState(() => loadSave().highScore);
+  const [upgrades, setUpgrades] = useState(() => loadSave().upgrades);
+  const [totalRuns, setTotalRuns] = useState(() => loadSave().totalRuns);
+  const [lastResult, setLastResult] = useState<ReturnType<typeof calculateResult> | null>(null);
+
+  // --- Input handling ---
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const k = keysRef.current;
+      if (e.key === 'ArrowLeft' || e.key === 'a') k.left = true;
+      if (e.key === 'ArrowRight' || e.key === 'd') k.right = true;
+      if (e.key === 'ArrowUp' || e.key === 'w') k.up = true;
+      if (e.key === 'ArrowDown' || e.key === 's') k.down = true;
+      if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+        e.preventDefault();
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      const k = keysRef.current;
+      if (e.key === 'ArrowLeft' || e.key === 'a') k.left = false;
+      if (e.key === 'ArrowRight' || e.key === 'd') k.right = false;
+      if (e.key === 'ArrowUp' || e.key === 'w') k.up = false;
+      if (e.key === 'ArrowDown' || e.key === 's') k.down = false;
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+  }, []);
+
+  // --- Game loop ---
+
+  const gameLoop = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const state = stateRef.current;
+    if (!state) return;
+
+    const keys = keysRef.current;
+    frameRef.current++;
+
+    // Phase-specific updates
+    if (state.phase === 'run') {
+      state.runner = updateRunner(state.runner, keys);
+
+      // Jump into cart at marker 1
+      if (keys.up && state.runner.passedMarker1 && !state.cart.inCart) {
+        state.phase = 'launch';
+        setPhase('launch');
+      }
+
+      // Auto-launch if past ramp
+      if (state.runner.pos.x >= HILL_END_X + RAMP_WIDTH) {
+        if (!state.cart.inCart) {
+          // Missed the cart - just reset
+          state.phase = 'results';
+          setPhase('results');
+          const result = calculateResult(0, 0, 0, true, state.upgrades);
+          state.lastResult = result;
+          setLastResult(result);
+        }
+      }
+
+      state.cameraX = Math.max(0, state.runner.pos.x - 200);
+    }
+
+    if (state.phase === 'launch') {
+      state.runner = updateRunner(state.runner, keys);
+      state.cameraX = Math.max(0, state.runner.pos.x - 200);
+
+      if (state.runner.pos.x >= HILL_END_X + RAMP_WIDTH - 10) {
+        state.cart = launchCart(state.runner, state.upgrades);
+        state.phase = 'flight';
+        setPhase('flight');
+        maxHeightRef.current = 0;
+      }
+    }
+
+    if (state.phase === 'flight') {
+      state.cart = updateCartFlight(state.cart, keys, state.upgrades);
+      state.tricks = updateTricks(state.tricks, state.cart, keys, state.upgrades);
+
+      const height = getHeight(state.cart);
+      if (height > maxHeightRef.current) maxHeightRef.current = height;
+
+      state.cameraX = Math.max(0, state.cart.pos.x - 300);
+
+      if (state.cart.onGround) {
+        if (state.cart.crashed) {
+          state.phase = 'landing';
+          setPhase('landing');
+          setTimeout(() => {
+            finishRun(state);
+          }, 1500);
+        } else {
+          state.phase = 'landing';
+          setPhase('landing');
+        }
+      }
+    }
+
+    if (state.phase === 'landing' && !state.cart.crashed) {
+      state.cart = updateCartRolling(state.cart, state.upgrades);
+      state.cameraX = Math.max(0, state.cart.pos.x - 300);
+
+      if (state.cart.vel.x <= 0) {
+        finishRun(state);
+      }
+    }
+
+    // Render
+    render(
+      ctx, state.phase, state.cart, state.runner, state.tricks,
+      state.upgrades, state.cameraX, frameRef.current, state.money,
+    );
+
+    if (state.phase !== 'menu' && state.phase !== 'shop' && state.phase !== 'results') {
+      animRef.current = requestAnimationFrame(gameLoop);
+    }
+  }, []);
+
+  const finishRun = useCallback((state: GameState) => {
+    const dist = getDistance(state.cart);
+    const result = calculateResult(
+      dist, maxHeightRef.current, state.tricks.trickPoints,
+      state.cart.crashed, state.upgrades,
+    );
+
+    state.lastResult = result;
+    setLastResult(result);
+
+    const newMoney = state.money + result.moneyEarned;
+    const newHighScore = Math.max(state.highScore, result.totalScore);
+    const newRuns = state.totalRuns + 1;
+
+    // Lose groupies on crash
+    const newUpgrades = state.cart.crashed
+      ? { ...state.upgrades, groupies: 0 }
+      : state.upgrades;
+
+    state.money = newMoney;
+    state.highScore = newHighScore;
+    state.totalRuns = newRuns;
+    state.upgrades = newUpgrades;
+
+    setMoney(newMoney);
+    setHighScore(newHighScore);
+    setTotalRuns(newRuns);
+    setUpgrades(newUpgrades);
+    saveToDisk(newMoney, newHighScore, newUpgrades, newRuns);
+
+    state.phase = 'results';
+    setPhase('results');
+  }, []);
+
+  // --- Phase transitions ---
+
+  const startRun = useCallback(() => {
+    const state: GameState = {
+      phase: 'run',
+      money,
+      highScore,
+      totalRuns,
+      upgrades: { ...upgrades },
+      cart: createCart(),
+      runner: createRunner(),
+      tricks: createTrickState(),
+      lastResult: null,
+      cameraX: 0,
+      groundY: FLAT_GROUND_Y,
+    };
+    stateRef.current = state;
+    maxHeightRef.current = 0;
+    setPhase('run');
+    setLastResult(null);
+
+    animRef.current = requestAnimationFrame(gameLoop);
+  }, [money, highScore, totalRuns, upgrades, gameLoop]);
+
+  const goToShop = useCallback(() => {
+    cancelAnimationFrame(animRef.current);
+    setPhase('shop');
+  }, []);
+
+  const handlePurchase = useCallback((upgradeId: string) => {
+    const result = purchaseUpgrade(upgrades, money, upgradeId);
+    if (result.success) {
+      setUpgrades(result.upgrades);
+      setMoney(result.money);
+      saveToDisk(result.money, highScore, result.upgrades, totalRuns);
+    }
+  }, [upgrades, money, highScore, totalRuns]);
+
+  // --- Cleanup ---
+
+  useEffect(() => {
+    return () => cancelAnimationFrame(animRef.current);
+  }, []);
+
+  // --- Render canvas for menu ---
+
+  useEffect(() => {
+    if (phase === 'menu') {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      // Draw static menu scene
+      const state: GameState = {
+        phase: 'menu',
+        money, highScore, totalRuns,
+        upgrades: { ...upgrades },
+        cart: createCart(),
+        runner: { ...createRunner(), pos: { x: HILL_START_X + 80, y: 0 }, speed: 0, frame: 0, passedMarker1: false, passedMarker2: false },
+        tricks: createTrickState(),
+        lastResult: null,
+        cameraX: 0,
+        groundY: FLAT_GROUND_Y,
+      };
+      state.runner.pos.y = 130;
+      render(ctx, 'run', state.cart, state.runner, state.tricks, state.upgrades, 0, 0, money);
+    }
+  }, [phase, money, highScore, totalRuns, upgrades]);
+
+  // --- UI ---
+
+  return (
+    <div className="min-h-screen bg-gray-900 flex flex-col items-center justify-center p-4">
+      <div className="relative">
+        <canvas
+          ref={canvasRef}
+          width={CANVAS_WIDTH}
+          height={CANVAS_HEIGHT}
+          className="border-2 border-gray-600 rounded-lg shadow-2xl"
+          style={{ imageRendering: 'pixelated' }}
+        />
+
+        {/* Menu overlay */}
+        {phase === 'menu' && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/60 rounded-lg">
+            <h1 className="text-5xl font-bold text-white mb-2 drop-shadow-lg" style={{ fontFamily: 'monospace' }}>
+              SHOPPING CART
+            </h1>
+            <h2 className="text-3xl font-bold text-yellow-400 mb-8 drop-shadow-lg" style={{ fontFamily: 'monospace' }}>
+              HERO
+            </h2>
+            {highScore > 0 && (
+              <p className="text-gray-300 mb-4 font-mono">High Score: {highScore} | Runs: {totalRuns}</p>
+            )}
+            <div className="flex gap-4">
+              <button
+                onClick={() => setPhase('shop')}
+                className="px-8 py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-lg text-lg transition-colors font-mono"
+              >
+                PLAY
+              </button>
+            </div>
+            <p className="text-gray-400 text-sm mt-6 font-mono">Arrow keys to play | RIGHT = run | UP = jump</p>
+          </div>
+        )}
+
+        {/* Shop overlay */}
+        {phase === 'shop' && (
+          <div className="absolute inset-0 bg-gray-900/95 rounded-lg overflow-y-auto p-6">
+            <div className="flex justify-between items-center mb-6">
+              <h2 className="text-2xl font-bold text-white font-mono">UPGRADE SHOP</h2>
+              <div className="text-yellow-400 font-bold text-xl font-mono">${money}</div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4 mb-6">
+              {/* Wheels */}
+              <ShopCategory
+                title="Wheels"
+                tiers={WHEEL_UPGRADES.tiers}
+                currentTier={upgrades.wheels}
+                money={money}
+                onBuy={(i) => handlePurchase(`wheels_${i}`)}
+              />
+
+              {/* Rockets */}
+              <ShopCategory
+                title="Rockets"
+                tiers={ROCKET_UPGRADES.tiers}
+                currentTier={upgrades.rockets}
+                money={money}
+                onBuy={(i) => handlePurchase(`rockets_${i}`)}
+              />
+
+              {/* Armor */}
+              <ShopCategory
+                title="Armor"
+                tiers={ARMOR_UPGRADES.tiers}
+                currentTier={upgrades.armor}
+                money={money}
+                onBuy={(i) => handlePurchase(`armor_${i}`)}
+              />
+
+              {/* Tricks */}
+              <div className="bg-gray-800 rounded-lg p-4">
+                <h3 className="text-lg font-bold text-white mb-3 font-mono">Tricks</h3>
+                {TRICK_DEFS.map((trick, i) => {
+                  const owned = upgrades[trick.id as keyof typeof upgrades];
+                  return (
+                    <div key={trick.id} className="flex justify-between items-center mb-2">
+                      <div>
+                        <span className={`font-mono text-sm ${owned ? 'text-green-400' : 'text-gray-300'}`}>
+                          {trick.name}
+                        </span>
+                        <span className="text-gray-500 text-xs ml-2">{trick.description}</span>
+                      </div>
+                      {owned ? (
+                        <span className="text-green-400 text-xs font-mono">OWNED</span>
+                      ) : (
+                        <button
+                          disabled={money < trick.cost}
+                          onClick={() => handlePurchase(`trick_${i}`)}
+                          className="px-3 py-1 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-600 disabled:text-gray-400 text-white text-xs rounded font-mono transition-colors"
+                        >
+                          ${trick.cost}
+                        </button>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Groupies */}
+            <div className="bg-gray-800 rounded-lg p-4 mb-6">
+              <h3 className="text-lg font-bold text-white mb-3 font-mono">
+                Groupies ({upgrades.groupies}/3) — {GROUPIE_MULTIPLIERS[upgrades.groupies]}x multiplier
+              </h3>
+              <p className="text-gray-400 text-xs mb-3 font-mono">Warning: Lost on crash!</p>
+              <div className="flex gap-3">
+                {GROUPIE_COSTS.map((cost, i) => (
+                  <button
+                    key={i}
+                    disabled={upgrades.groupies > i || money < cost}
+                    onClick={() => handlePurchase(`groupie_${i}`)}
+                    className="px-4 py-2 bg-purple-600 hover:bg-purple-500 disabled:bg-gray-600 disabled:text-gray-400 text-white text-sm rounded font-mono transition-colors"
+                  >
+                    {upgrades.groupies > i ? 'HIRED' : `Groupie ${i + 1} — $${cost}`}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex justify-center">
+              <button
+                onClick={startRun}
+                className="px-12 py-4 bg-green-600 hover:bg-green-500 text-white font-bold rounded-lg text-xl transition-colors font-mono"
+              >
+                GO!
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Results overlay */}
+        {phase === 'results' && lastResult && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/70 rounded-lg">
+            <h2 className="text-3xl font-bold text-white mb-6 font-mono">
+              {lastResult.crashed ? 'CRASHED!' : 'RUN COMPLETE!'}
+            </h2>
+
+            <div className="bg-gray-800 rounded-lg p-6 mb-6 min-w-[300px]">
+              <div className="space-y-2 text-lg font-mono">
+                <div className="flex justify-between text-gray-300">
+                  <span>Distance:</span>
+                  <span className="text-white">{lastResult.distance}m</span>
+                </div>
+                <div className="flex justify-between text-gray-300">
+                  <span>Max Height:</span>
+                  <span className="text-white">{lastResult.maxHeight}m</span>
+                </div>
+                <div className="flex justify-between text-gray-300">
+                  <span>Tricks:</span>
+                  <span className="text-white">{lastResult.trickPoints} pts</span>
+                </div>
+                {lastResult.groupiesLost > 0 && (
+                  <div className="flex justify-between text-red-400">
+                    <span>Groupies Lost:</span>
+                    <span>{lastResult.groupiesLost}</span>
+                  </div>
+                )}
+                <div className="border-t border-gray-600 pt-2 mt-2 flex justify-between text-yellow-400 font-bold">
+                  <span>Money Earned:</span>
+                  <span>${lastResult.moneyEarned}</span>
+                </div>
+                <div className="flex justify-between text-green-400 font-bold text-xl">
+                  <span>Total Score:</span>
+                  <span>{lastResult.totalScore}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <button
+                onClick={goToShop}
+                className="px-8 py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-lg text-lg transition-colors font-mono"
+              >
+                SHOP
+              </button>
+              <button
+                onClick={startRun}
+                className="px-8 py-3 bg-green-600 hover:bg-green-500 text-white font-bold rounded-lg text-lg transition-colors font-mono"
+              >
+                RETRY
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Controls hint */}
+      {(phase === 'run' || phase === 'launch' || phase === 'flight') && (
+        <div className="mt-4 text-gray-400 text-sm font-mono text-center">
+          {phase === 'run' && 'Hold RIGHT to run → Press UP at orange marker to jump in cart'}
+          {phase === 'launch' && 'Running to ramp...'}
+          {phase === 'flight' && 'LEFT/RIGHT to rotate | DOWN = Handstand | UP = Superman'}
+        </div>
+      )}
+
+      <Link to="/games" className="mt-4 text-gray-500 hover:text-gray-300 text-sm font-mono transition-colors">
+        ← Back to Games
+      </Link>
+    </div>
+  );
+}
+
+// --- Shop Category Component ---
+
+function ShopCategory({
+  title,
+  tiers,
+  currentTier,
+  money,
+  onBuy,
+}: {
+  title: string;
+  tiers: { name: string; cost: number; description: string }[];
+  currentTier: number;
+  money: number;
+  onBuy: (tierIndex: number) => void;
+}) {
+  return (
+    <div className="bg-gray-800 rounded-lg p-4">
+      <h3 className="text-lg font-bold text-white mb-3 font-mono">{title}</h3>
+      {tiers.map((tier, i) => {
+        const owned = currentTier >= i;
+        const nextTier = i === currentTier + 1;
+        return (
+          <div key={i} className="flex justify-between items-center mb-2">
+            <div>
+              <span className={`font-mono text-sm ${owned ? 'text-green-400' : nextTier ? 'text-white' : 'text-gray-500'}`}>
+                {tier.name}
+              </span>
+              <span className="text-gray-500 text-xs ml-2">{tier.description}</span>
+            </div>
+            {owned ? (
+              <span className="text-green-400 text-xs font-mono">{i === currentTier ? 'EQUIPPED' : 'OWNED'}</span>
+            ) : nextTier ? (
+              <button
+                disabled={money < tier.cost}
+                onClick={() => onBuy(i)}
+                className="px-3 py-1 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-600 disabled:text-gray-400 text-white text-xs rounded font-mono transition-colors"
+              >
+                ${tier.cost}
+              </button>
+            ) : (
+              <span className="text-gray-600 text-xs font-mono">${tier.cost}</span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/game/shopping-cart-hero/physics.ts
+++ b/src/components/game/shopping-cart-hero/physics.ts
@@ -199,7 +199,9 @@ export function updateCartRolling(cart: CartState, upgrades: PlayerUpgrades): Ca
   };
 
   const wheelMult = WHEEL_MULTIPLIERS[upgrades.wheels];
-  next.vel.x *= ROLL_FRICTION * (1 + (wheelMult - 1) * 0.1);
+  // Better wheels = less friction (higher multiplier = closer to 1.0)
+  const adjustedFriction = 1 - (1 - ROLL_FRICTION) / wheelMult;
+  next.vel.x *= adjustedFriction;
   next.pos.x += next.vel.x;
 
   // Stop when slow enough

--- a/src/components/game/shopping-cart-hero/physics.ts
+++ b/src/components/game/shopping-cart-hero/physics.ts
@@ -1,0 +1,298 @@
+// ============================================================================
+// Shopping Cart Hero — Physics Engine
+// ============================================================================
+
+import type { CartState, RunnerState, TrickState, PlayerUpgrades, InputKeys } from './types';
+import {
+  GRAVITY, AIR_DRAG, ROTATION_SPEED, BOUNCE_COEFFICIENT, ROLL_FRICTION,
+  MIN_BOUNCE_VEL, RUN_ACCELERATION, MAX_RUN_SPEED,
+  HILL_START_X, HILL_START_Y, HILL_END_X, HILL_END_Y,
+  RAMP_WIDTH, LAUNCH_ANGLE, LAUNCH_SPEED_MULT, FLAT_GROUND_Y,
+  MARKER_1_X, MARKER_2_X,
+  WHEEL_MULTIPLIERS, ROCKET_CONFIGS, ARMOR_CRASH_ANGLES,
+  FLIP_POINTS, HANDSTAND_POINTS, SUPERMAN_POINTS,
+} from './constants';
+
+// --- Hill geometry helpers ---
+
+function getHillY(x: number): number {
+  if (x < HILL_START_X) return HILL_START_Y;
+  if (x > HILL_END_X) return FLAT_GROUND_Y;
+  const t = (x - HILL_START_X) / (HILL_END_X - HILL_START_X);
+  return HILL_START_Y + t * (HILL_END_Y - HILL_START_Y);
+}
+
+function getGroundY(x: number): number {
+  if (x <= HILL_END_X + RAMP_WIDTH) return getHillY(x);
+  return FLAT_GROUND_Y;
+}
+
+// --- Runner physics ---
+
+export function createRunner(): RunnerState {
+  return {
+    pos: { x: HILL_START_X + 20, y: getHillY(HILL_START_X + 20) - 20 },
+    speed: 0,
+    frame: 0,
+    passedMarker1: false,
+    passedMarker2: false,
+  };
+}
+
+export function updateRunner(runner: RunnerState, keys: InputKeys): RunnerState {
+  const next = { ...runner };
+
+  if (keys.right) {
+    next.speed = Math.min(next.speed + RUN_ACCELERATION, MAX_RUN_SPEED);
+  } else {
+    next.speed = Math.max(0, next.speed - 0.1);
+  }
+
+  next.pos = { ...next.pos };
+  next.pos.x += next.speed;
+  next.pos.y = getHillY(next.pos.x) - 20;
+
+  next.frame = next.speed > 0.5 ? (next.frame + 0.2) % 4 : 0;
+
+  if (next.pos.x >= MARKER_1_X) next.passedMarker1 = true;
+  if (next.pos.x >= MARKER_2_X) next.passedMarker2 = true;
+
+  return next;
+}
+
+// --- Cart physics ---
+
+export function createCart(): CartState {
+  return {
+    pos: { x: 0, y: 0 },
+    vel: { x: 0, y: 0 },
+    angle: 0,
+    angularVel: 0,
+    onGround: false,
+    crashed: false,
+    inCart: false,
+    rocketFuel: 0,
+    rocketActive: false,
+    bounceCount: 0,
+    rolling: false,
+  };
+}
+
+export function launchCart(runner: RunnerState, upgrades: PlayerUpgrades): CartState {
+  const speed = runner.speed * LAUNCH_SPEED_MULT;
+  const rocketConfig = ROCKET_CONFIGS[upgrades.rockets];
+
+  return {
+    pos: { x: HILL_END_X + RAMP_WIDTH, y: HILL_END_Y - 10 },
+    vel: {
+      x: speed * Math.cos(LAUNCH_ANGLE),
+      y: speed * Math.sin(LAUNCH_ANGLE),
+    },
+    angle: LAUNCH_ANGLE * 0.3,
+    angularVel: 0,
+    onGround: false,
+    crashed: false,
+    inCart: true,
+    rocketFuel: rocketConfig.frames,
+    rocketActive: false,
+    bounceCount: 0,
+    rolling: false,
+  };
+}
+
+export function updateCartFlight(
+  cart: CartState,
+  keys: InputKeys,
+  upgrades: PlayerUpgrades,
+): CartState {
+  const next: CartState = {
+    ...cart,
+    pos: { ...cart.pos },
+    vel: { ...cart.vel },
+  };
+
+  // Gravity
+  next.vel.y += GRAVITY;
+
+  // Air drag
+  next.vel.x *= AIR_DRAG;
+  next.vel.y *= AIR_DRAG;
+
+  // Rockets
+  if (next.rocketFuel > 0) {
+    next.rocketActive = true;
+    const rocketConfig = ROCKET_CONFIGS[upgrades.rockets];
+    next.vel.x += Math.cos(next.angle) * rocketConfig.force * 0.3;
+    next.vel.y -= rocketConfig.force * 0.5;
+    next.rocketFuel--;
+  } else {
+    next.rocketActive = false;
+  }
+
+  // Rotation from input
+  if (keys.left) {
+    next.angularVel -= ROTATION_SPEED * 0.3;
+  }
+  if (keys.right) {
+    next.angularVel += ROTATION_SPEED * 0.3;
+  }
+  next.angularVel *= 0.95; // angular damping
+  next.angle += next.angularVel;
+
+  // Position update
+  next.pos.x += next.vel.x;
+  next.pos.y += next.vel.y;
+
+  // Ground collision
+  const ground = getGroundY(next.pos.x);
+  if (next.pos.y >= ground - 15) {
+    next.pos.y = ground - 15;
+    return handleLanding(next, upgrades);
+  }
+
+  return next;
+}
+
+function handleLanding(cart: CartState, upgrades: PlayerUpgrades): CartState {
+  const next = { ...cart };
+  const crashAngle = ARMOR_CRASH_ANGLES[upgrades.armor];
+
+  // Normalize angle to [-PI, PI]
+  let normalizedAngle = next.angle % (Math.PI * 2);
+  if (normalizedAngle > Math.PI) normalizedAngle -= Math.PI * 2;
+  if (normalizedAngle < -Math.PI) normalizedAngle += Math.PI * 2;
+
+  const angleFromLevel = Math.abs(normalizedAngle);
+
+  if (angleFromLevel > crashAngle) {
+    next.crashed = true;
+    next.vel = { x: 0, y: 0 };
+    next.angularVel = 0;
+    next.onGround = true;
+    return next;
+  }
+
+  // Bounce
+  if (Math.abs(next.vel.y) > MIN_BOUNCE_VEL && next.bounceCount < 3) {
+    next.vel.y = -next.vel.y * BOUNCE_COEFFICIENT;
+    next.vel.x *= 0.9;
+    next.bounceCount++;
+    next.angularVel *= 0.5;
+    return next;
+  }
+
+  // Start rolling
+  next.onGround = true;
+  next.rolling = true;
+  next.vel.y = 0;
+  next.angle = 0;
+  next.angularVel = 0;
+
+  return next;
+}
+
+export function updateCartRolling(cart: CartState, upgrades: PlayerUpgrades): CartState {
+  const next: CartState = {
+    ...cart,
+    pos: { ...cart.pos },
+    vel: { ...cart.vel },
+  };
+
+  const wheelMult = WHEEL_MULTIPLIERS[upgrades.wheels];
+  next.vel.x *= ROLL_FRICTION * (1 + (wheelMult - 1) * 0.1);
+  next.pos.x += next.vel.x;
+
+  // Stop when slow enough
+  if (Math.abs(next.vel.x) < 0.3) {
+    next.vel.x = 0;
+  }
+
+  return next;
+}
+
+// --- Trick detection ---
+
+export function createTrickState(): TrickState {
+  return {
+    totalRotation: 0,
+    flipsCompleted: 0,
+    handstandActive: false,
+    handstandFrames: 0,
+    supermanActive: false,
+    supermanFrames: 0,
+    trickPoints: 0,
+    comboText: '',
+    comboTimer: 0,
+  };
+}
+
+export function updateTricks(
+  tricks: TrickState,
+  cart: CartState,
+  keys: InputKeys,
+  upgrades: PlayerUpgrades,
+): TrickState {
+  if (cart.onGround || cart.crashed) return tricks;
+
+  const next = { ...tricks };
+
+  // Track rotation for flips
+  next.totalRotation += cart.angularVel;
+  const newFlips = Math.floor(Math.abs(next.totalRotation) / (Math.PI * 2));
+  if (newFlips > next.flipsCompleted) {
+    const earned = (newFlips - next.flipsCompleted) * FLIP_POINTS;
+    next.trickPoints += earned;
+    next.flipsCompleted = newFlips;
+    next.comboText = `FLIP! +${earned}`;
+    next.comboTimer = 60;
+  }
+
+  // Handstand (hold DOWN)
+  if (keys.down && upgrades.handstand && !next.supermanActive) {
+    if (!next.handstandActive) {
+      next.handstandActive = true;
+      next.handstandFrames = 0;
+    }
+    next.handstandFrames++;
+    if (next.handstandFrames % 30 === 0) {
+      next.trickPoints += HANDSTAND_POINTS;
+      next.comboText = `HANDSTAND! +${HANDSTAND_POINTS}`;
+      next.comboTimer = 60;
+    }
+  } else {
+    next.handstandActive = false;
+    next.handstandFrames = 0;
+  }
+
+  // Superman (hold UP)
+  if (keys.up && upgrades.superman && !next.handstandActive) {
+    if (!next.supermanActive) {
+      next.supermanActive = true;
+      next.supermanFrames = 0;
+    }
+    next.supermanFrames++;
+    if (next.supermanFrames % 30 === 0) {
+      next.trickPoints += SUPERMAN_POINTS;
+      next.comboText = `SUPERMAN! +${SUPERMAN_POINTS}`;
+      next.comboTimer = 60;
+    }
+  } else {
+    next.supermanActive = false;
+    next.supermanFrames = 0;
+  }
+
+  // Combo timer
+  if (next.comboTimer > 0) next.comboTimer--;
+
+  return next;
+}
+
+// --- Distance / height tracking ---
+
+export function getDistance(cart: CartState): number {
+  return Math.max(0, Math.floor(cart.pos.x - (HILL_END_X + RAMP_WIDTH)));
+}
+
+export function getHeight(cart: CartState): number {
+  return Math.max(0, Math.floor(FLAT_GROUND_Y - cart.pos.y));
+}

--- a/src/components/game/shopping-cart-hero/renderer.ts
+++ b/src/components/game/shopping-cart-hero/renderer.ts
@@ -1,0 +1,586 @@
+// ============================================================================
+// Shopping Cart Hero — Canvas Renderer
+// ============================================================================
+
+import type { CartState, RunnerState, TrickState, PlayerUpgrades, GamePhase } from './types';
+import {
+  CANVAS_WIDTH, CANVAS_HEIGHT, COLORS,
+  HILL_START_X, HILL_START_Y, HILL_END_X, HILL_END_Y,
+  RAMP_WIDTH, MARKER_1_X, MARKER_2_X, FLAT_GROUND_Y,
+} from './constants';
+import { getDistance, getHeight } from './physics';
+
+// --- Main render ---
+
+export function render(
+  ctx: CanvasRenderingContext2D,
+  phase: GamePhase,
+  cart: CartState,
+  runner: RunnerState,
+  tricks: TrickState,
+  upgrades: PlayerUpgrades,
+  cameraX: number,
+  frameCount: number,
+  money: number,
+) {
+  ctx.save();
+  ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+  drawSky(ctx, frameCount);
+  drawClouds(ctx, cameraX, frameCount);
+  drawBuildings(ctx, cameraX);
+
+  ctx.translate(-cameraX, 0);
+
+  drawGround(ctx, cameraX);
+  drawHill(ctx);
+  drawRamp(ctx);
+  drawMarkers(ctx);
+
+  if (phase === 'run' || phase === 'launch') {
+    drawRunner(ctx, runner);
+  }
+
+  if (phase === 'flight' || phase === 'landing' || phase === 'results') {
+    drawCart(ctx, cart, upgrades, tricks, frameCount);
+  }
+
+  ctx.restore();
+
+  // HUD (screen-space)
+  if (phase === 'flight' || phase === 'landing') {
+    drawHUD(ctx, cart, tricks, money);
+  }
+
+  if (phase === 'flight' && tricks.comboTimer > 0) {
+    drawComboText(ctx, tricks);
+  }
+
+  if (cart.crashed && (phase === 'landing' || phase === 'results')) {
+    drawCrashEffect(ctx, frameCount);
+  }
+}
+
+// --- Sky ---
+
+function drawSky(ctx: CanvasRenderingContext2D, _frame: number) {
+  const gradient = ctx.createLinearGradient(0, 0, 0, CANVAS_HEIGHT);
+  gradient.addColorStop(0, COLORS.sky);
+  gradient.addColorStop(0.7, COLORS.skyHorizon);
+  gradient.addColorStop(1, COLORS.ground);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+}
+
+// --- Clouds (parallax) ---
+
+function drawClouds(ctx: CanvasRenderingContext2D, cameraX: number, frame: number) {
+  ctx.fillStyle = COLORS.cloud;
+  const cloudPositions = [
+    { x: 100, y: 40, w: 80, h: 25 },
+    { x: 350, y: 60, w: 100, h: 30 },
+    { x: 600, y: 30, w: 70, h: 20 },
+    { x: 900, y: 50, w: 90, h: 28 },
+    { x: 1200, y: 35, w: 110, h: 32 },
+    { x: 1600, y: 55, w: 85, h: 24 },
+    { x: 2000, y: 42, w: 95, h: 27 },
+  ];
+
+  for (const cloud of cloudPositions) {
+    const parallaxX = cloud.x - cameraX * 0.15 + Math.sin(frame * 0.005 + cloud.x) * 3;
+    const screenX = ((parallaxX % 2400) + 2400) % 2400 - 200;
+    drawCloud(ctx, screenX, cloud.y, cloud.w, cloud.h);
+  }
+}
+
+function drawCloud(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number) {
+  ctx.beginPath();
+  ctx.ellipse(x, y, w / 2, h / 2, 0, 0, Math.PI * 2);
+  ctx.ellipse(x - w / 4, y + h / 4, w / 3, h / 3, 0, 0, Math.PI * 2);
+  ctx.ellipse(x + w / 4, y + h / 4, w / 3, h / 3, 0, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+// --- Distant buildings (parallax) ---
+
+function drawBuildings(ctx: CanvasRenderingContext2D, cameraX: number) {
+  const buildingDefs = [
+    { x: 200, w: 50, h: 80 },
+    { x: 310, w: 35, h: 60 },
+    { x: 400, w: 60, h: 100 },
+    { x: 520, w: 40, h: 70 },
+    { x: 650, w: 55, h: 90 },
+    { x: 800, w: 45, h: 75 },
+    { x: 950, w: 50, h: 85 },
+    { x: 1100, w: 60, h: 110 },
+    { x: 1300, w: 40, h: 65 },
+  ];
+
+  for (const b of buildingDefs) {
+    const parallaxX = b.x - cameraX * 0.3;
+    const screenX = ((parallaxX % 1600) + 1600) % 1600 - 200;
+    const baseY = FLAT_GROUND_Y - 10;
+
+    ctx.fillStyle = COLORS.building;
+    ctx.fillRect(screenX, baseY - b.h, b.w, b.h);
+    ctx.fillStyle = COLORS.buildingDark;
+    ctx.fillRect(screenX, baseY - b.h, b.w, 3);
+
+    // Windows
+    ctx.fillStyle = COLORS.window;
+    for (let wy = baseY - b.h + 10; wy < baseY - 5; wy += 15) {
+      for (let wx = screenX + 6; wx < screenX + b.w - 6; wx += 12) {
+        ctx.fillRect(wx, wy, 6, 8);
+      }
+    }
+  }
+}
+
+// --- Ground ---
+
+function drawGround(ctx: CanvasRenderingContext2D, cameraX: number) {
+  ctx.fillStyle = COLORS.ground;
+  ctx.fillRect(cameraX, FLAT_GROUND_Y, CANVAS_WIDTH + 200, CANVAS_HEIGHT - FLAT_GROUND_Y + 100);
+
+  // Ground detail stripes
+  ctx.fillStyle = COLORS.groundDark;
+  for (let x = Math.floor(cameraX / 40) * 40; x < cameraX + CANVAS_WIDTH + 40; x += 40) {
+    ctx.fillRect(x, FLAT_GROUND_Y, 2, 10);
+  }
+
+  // Dirt layer
+  ctx.fillStyle = COLORS.dirt;
+  ctx.fillRect(cameraX, FLAT_GROUND_Y + 10, CANVAS_WIDTH + 200, CANVAS_HEIGHT);
+}
+
+// --- Hill ---
+
+function drawHill(ctx: CanvasRenderingContext2D) {
+  ctx.fillStyle = COLORS.hill;
+  ctx.beginPath();
+  ctx.moveTo(0, CANVAS_HEIGHT);
+  ctx.lineTo(0, HILL_START_Y);
+  ctx.lineTo(HILL_START_X, HILL_START_Y);
+  ctx.lineTo(HILL_END_X, HILL_END_Y);
+  ctx.lineTo(HILL_END_X, CANVAS_HEIGHT);
+  ctx.closePath();
+  ctx.fill();
+
+  // Hill surface line
+  ctx.strokeStyle = COLORS.hillDark;
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(HILL_START_X, HILL_START_Y);
+  ctx.lineTo(HILL_END_X, HILL_END_Y);
+  ctx.stroke();
+
+  // Grass tufts
+  ctx.strokeStyle = '#3d7a2a';
+  ctx.lineWidth = 2;
+  for (let x = HILL_START_X; x < HILL_END_X; x += 25) {
+    const t = (x - HILL_START_X) / (HILL_END_X - HILL_START_X);
+    const y = HILL_START_Y + t * (HILL_END_Y - HILL_START_Y);
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    ctx.lineTo(x - 3, y - 6);
+    ctx.moveTo(x, y);
+    ctx.lineTo(x + 3, y - 5);
+    ctx.stroke();
+  }
+}
+
+// --- Ramp ---
+
+function drawRamp(ctx: CanvasRenderingContext2D) {
+  ctx.fillStyle = COLORS.ramp;
+  ctx.beginPath();
+  ctx.moveTo(HILL_END_X, HILL_END_Y);
+  ctx.lineTo(HILL_END_X + RAMP_WIDTH, FLAT_GROUND_Y);
+  ctx.lineTo(HILL_END_X + RAMP_WIDTH, FLAT_GROUND_Y + 8);
+  ctx.lineTo(HILL_END_X, HILL_END_Y + 8);
+  ctx.closePath();
+  ctx.fill();
+
+  // Ramp top edge highlight
+  ctx.strokeStyle = COLORS.rampLight;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(HILL_END_X, HILL_END_Y);
+  ctx.lineTo(HILL_END_X + RAMP_WIDTH, FLAT_GROUND_Y);
+  ctx.stroke();
+}
+
+// --- Markers ---
+
+function drawMarkers(ctx: CanvasRenderingContext2D) {
+  const markers = [MARKER_1_X, MARKER_2_X];
+  for (const mx of markers) {
+    const t = (mx - HILL_START_X) / (HILL_END_X - HILL_START_X);
+    const my = HILL_START_Y + t * (HILL_END_Y - HILL_START_Y);
+
+    // Post
+    ctx.strokeStyle = COLORS.marker;
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.moveTo(mx, my);
+    ctx.lineTo(mx, my - 35);
+    ctx.stroke();
+
+    // Flag
+    ctx.fillStyle = COLORS.markerFlag;
+    ctx.beginPath();
+    ctx.moveTo(mx, my - 35);
+    ctx.lineTo(mx + 15, my - 30);
+    ctx.lineTo(mx, my - 25);
+    ctx.closePath();
+    ctx.fill();
+  }
+}
+
+// --- Stickman runner ---
+
+function drawRunner(ctx: CanvasRenderingContext2D, runner: RunnerState) {
+  const { x, y } = runner.pos;
+  const legPhase = Math.sin(runner.frame * Math.PI);
+
+  ctx.strokeStyle = COLORS.stickman;
+  ctx.lineWidth = 3;
+  ctx.lineCap = 'round';
+
+  // Head
+  ctx.beginPath();
+  ctx.arc(x, y - 20, 6, 0, Math.PI * 2);
+  ctx.stroke();
+
+  // Body
+  ctx.beginPath();
+  ctx.moveTo(x, y - 14);
+  ctx.lineTo(x, y);
+  ctx.stroke();
+
+  // Arms (running animation)
+  ctx.beginPath();
+  ctx.moveTo(x, y - 10);
+  ctx.lineTo(x + 8 * legPhase, y - 5);
+  ctx.moveTo(x, y - 10);
+  ctx.lineTo(x - 8 * legPhase, y - 5);
+  ctx.stroke();
+
+  // Legs
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  ctx.lineTo(x + 8 * legPhase, y + 15);
+  ctx.moveTo(x, y);
+  ctx.lineTo(x - 8 * legPhase, y + 15);
+  ctx.stroke();
+}
+
+// --- Cart with stickman ---
+
+function drawCart(
+  ctx: CanvasRenderingContext2D,
+  cart: CartState,
+  upgrades: PlayerUpgrades,
+  tricks: TrickState,
+  frame: number,
+) {
+  ctx.save();
+  ctx.translate(cart.pos.x, cart.pos.y);
+  ctx.rotate(cart.angle);
+
+  // Cart body
+  ctx.fillStyle = COLORS.cart;
+  ctx.strokeStyle = COLORS.cartDark;
+  ctx.lineWidth = 2;
+  ctx.fillRect(-20, -15, 40, 20);
+  ctx.strokeRect(-20, -15, 40, 20);
+
+  // Cart handle
+  ctx.strokeStyle = COLORS.cartDark;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(-20, -15);
+  ctx.lineTo(-25, -30);
+  ctx.stroke();
+
+  // Wheels
+  ctx.fillStyle = COLORS.cartWheel;
+  ctx.beginPath();
+  ctx.arc(-12, 7, 5, 0, Math.PI * 2);
+  ctx.arc(12, 7, 5, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Wheel upgrade visual (bigger wheels)
+  if (upgrades.wheels >= 2) {
+    ctx.strokeStyle = '#555';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(-12, 7, 7, 0, Math.PI * 2);
+    ctx.arc(12, 7, 7, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+
+  // Stickman in cart
+  if (!cart.crashed) {
+    if (tricks.handstandActive) {
+      drawCartStickmanHandstand(ctx);
+    } else if (tricks.supermanActive) {
+      drawCartStickmanSuperman(ctx);
+    } else {
+      drawCartStickmanNormal(ctx);
+    }
+  } else {
+    drawCartStickmanCrashed(ctx);
+  }
+
+  // Groupies
+  for (let i = 0; i < upgrades.groupies; i++) {
+    drawGroupie(ctx, i);
+  }
+
+  // Rocket flame
+  if (cart.rocketActive) {
+    drawRocketFlame(ctx, frame);
+  }
+
+  ctx.restore();
+}
+
+function drawCartStickmanNormal(ctx: CanvasRenderingContext2D) {
+  ctx.strokeStyle = COLORS.stickman;
+  ctx.lineWidth = 2;
+  ctx.lineCap = 'round';
+
+  // Head
+  ctx.beginPath();
+  ctx.arc(0, -30, 5, 0, Math.PI * 2);
+  ctx.stroke();
+
+  // Body
+  ctx.beginPath();
+  ctx.moveTo(0, -25);
+  ctx.lineTo(0, -15);
+  ctx.stroke();
+
+  // Arms (holding cart handle)
+  ctx.beginPath();
+  ctx.moveTo(0, -22);
+  ctx.lineTo(-10, -18);
+  ctx.moveTo(0, -22);
+  ctx.lineTo(8, -18);
+  ctx.stroke();
+
+  // Legs (sitting)
+  ctx.beginPath();
+  ctx.moveTo(0, -15);
+  ctx.lineTo(-6, -10);
+  ctx.moveTo(0, -15);
+  ctx.lineTo(6, -10);
+  ctx.stroke();
+}
+
+function drawCartStickmanHandstand(ctx: CanvasRenderingContext2D) {
+  ctx.strokeStyle = COLORS.stickman;
+  ctx.lineWidth = 2;
+  ctx.lineCap = 'round';
+
+  // Hands on cart
+  ctx.beginPath();
+  ctx.moveTo(-5, -15);
+  ctx.lineTo(-5, -25);
+  ctx.moveTo(5, -15);
+  ctx.lineTo(5, -25);
+  ctx.stroke();
+
+  // Body (upside down)
+  ctx.beginPath();
+  ctx.moveTo(0, -25);
+  ctx.lineTo(0, -45);
+  ctx.stroke();
+
+  // Head (at top)
+  ctx.beginPath();
+  ctx.arc(0, -50, 5, 0, Math.PI * 2);
+  ctx.stroke();
+
+  // Legs (spread)
+  ctx.beginPath();
+  ctx.moveTo(0, -45);
+  ctx.lineTo(-6, -52);
+  ctx.moveTo(0, -45);
+  ctx.lineTo(6, -52);
+  ctx.stroke();
+}
+
+function drawCartStickmanSuperman(ctx: CanvasRenderingContext2D) {
+  ctx.strokeStyle = COLORS.stickman;
+  ctx.lineWidth = 2;
+  ctx.lineCap = 'round';
+
+  // Body stretched out behind cart
+  ctx.beginPath();
+  ctx.moveTo(0, -15);
+  ctx.lineTo(30, -18);
+  ctx.stroke();
+
+  // Head
+  ctx.beginPath();
+  ctx.arc(-5, -22, 5, 0, Math.PI * 2);
+  ctx.stroke();
+
+  // Arms stretched forward
+  ctx.beginPath();
+  ctx.moveTo(-3, -20);
+  ctx.lineTo(-18, -25);
+  ctx.moveTo(-3, -18);
+  ctx.lineTo(-18, -22);
+  ctx.stroke();
+
+  // Legs
+  ctx.beginPath();
+  ctx.moveTo(30, -18);
+  ctx.lineTo(38, -15);
+  ctx.moveTo(30, -18);
+  ctx.lineTo(38, -21);
+  ctx.stroke();
+}
+
+function drawCartStickmanCrashed(ctx: CanvasRenderingContext2D) {
+  ctx.strokeStyle = '#cc0000';
+  ctx.lineWidth = 2;
+  ctx.lineCap = 'round';
+
+  // Ragdoll stickman
+  ctx.beginPath();
+  ctx.arc(5, -20, 5, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.moveTo(5, -15);
+  ctx.lineTo(0, -5);
+  ctx.moveTo(5, -15);
+  ctx.lineTo(12, -8);
+  ctx.moveTo(0, -5);
+  ctx.lineTo(-5, 2);
+  ctx.moveTo(0, -5);
+  ctx.lineTo(8, 3);
+  ctx.stroke();
+
+  // X eyes
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  ctx.moveTo(3, -22);
+  ctx.lineTo(5, -20);
+  ctx.moveTo(5, -22);
+  ctx.lineTo(3, -20);
+  ctx.moveTo(6, -22);
+  ctx.lineTo(8, -20);
+  ctx.moveTo(8, -22);
+  ctx.lineTo(6, -20);
+  ctx.stroke();
+}
+
+function drawGroupie(ctx: CanvasRenderingContext2D, index: number) {
+  const offsetX = -8 + index * 8;
+  ctx.strokeStyle = '#4444cc';
+  ctx.lineWidth = 1.5;
+  ctx.lineCap = 'round';
+
+  // Small stickman
+  ctx.beginPath();
+  ctx.arc(offsetX, -26, 3, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(offsetX, -23);
+  ctx.lineTo(offsetX, -17);
+  ctx.moveTo(offsetX, -20);
+  ctx.lineTo(offsetX - 3, -18);
+  ctx.moveTo(offsetX, -20);
+  ctx.lineTo(offsetX + 3, -18);
+  ctx.stroke();
+}
+
+function drawRocketFlame(ctx: CanvasRenderingContext2D, frame: number) {
+  const flicker = Math.sin(frame * 0.5) * 5;
+  ctx.fillStyle = COLORS.rocketFlame;
+  ctx.beginPath();
+  ctx.moveTo(20, -5);
+  ctx.lineTo(35 + flicker, -2);
+  ctx.lineTo(20, 1);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = COLORS.rocket;
+  ctx.beginPath();
+  ctx.moveTo(20, -3);
+  ctx.lineTo(28 + flicker * 0.5, -1);
+  ctx.lineTo(20, 0);
+  ctx.closePath();
+  ctx.fill();
+}
+
+// --- HUD ---
+
+function drawHUD(ctx: CanvasRenderingContext2D, cart: CartState, tricks: TrickState, money: number) {
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+  roundRect(ctx, 10, 10, 200, 80, 8);
+  ctx.fill();
+
+  ctx.fillStyle = COLORS.text;
+  ctx.font = 'bold 14px monospace';
+  ctx.textAlign = 'left';
+
+  const dist = getDistance(cart);
+  const height = getHeight(cart);
+
+  ctx.fillText(`Distance: ${dist}m`, 20, 30);
+  ctx.fillText(`Height: ${height}m`, 20, 48);
+  ctx.fillText(`Tricks: ${tricks.trickPoints} pts`, 20, 66);
+
+  // Money
+  ctx.fillStyle = COLORS.money;
+  ctx.textAlign = 'right';
+  ctx.fillText(`$${money}`, CANVAS_WIDTH - 20, 30);
+}
+
+function drawComboText(ctx: CanvasRenderingContext2D, tricks: TrickState) {
+  const alpha = tricks.comboTimer / 60;
+  ctx.globalAlpha = alpha;
+  ctx.fillStyle = COLORS.money;
+  ctx.font = 'bold 24px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText(tricks.comboText, CANVAS_WIDTH / 2, 120 - (1 - alpha) * 20);
+  ctx.globalAlpha = 1;
+}
+
+function drawCrashEffect(ctx: CanvasRenderingContext2D, frame: number) {
+  const flash = Math.sin(frame * 0.3) * 0.3;
+  if (flash > 0) {
+    ctx.fillStyle = `rgba(255, 0, 0, ${flash})`;
+    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+  }
+
+  ctx.fillStyle = COLORS.crash;
+  ctx.font = 'bold 48px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText('CRASH!', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 - 40);
+}
+
+// --- Utility ---
+
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number, y: number, w: number, h: number, r: number,
+) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}

--- a/src/components/game/shopping-cart-hero/shop.ts
+++ b/src/components/game/shopping-cart-hero/shop.ts
@@ -1,0 +1,99 @@
+// ============================================================================
+// Shopping Cart Hero — Shop System
+// ============================================================================
+
+import type { PlayerUpgrades, RunResult } from './types';
+import {
+  GROUPIE_MULTIPLIERS, DISTANCE_SCORE_DIVISOR, HEIGHT_SCORE_DIVISOR,
+  WHEEL_UPGRADES, ROCKET_UPGRADES, ARMOR_UPGRADES,
+  TRICK_DEFS, GROUPIE_COSTS,
+} from './constants';
+
+// --- Score calculation ---
+
+export function calculateResult(
+  distance: number,
+  maxHeight: number,
+  trickPoints: number,
+  crashed: boolean,
+  upgrades: PlayerUpgrades,
+): RunResult {
+  const groupieMultiplier = GROUPIE_MULTIPLIERS[upgrades.groupies];
+  const groupiesLost = crashed ? upgrades.groupies : 0;
+
+  const baseScore = Math.floor(distance / DISTANCE_SCORE_DIVISOR)
+    + Math.floor(maxHeight / HEIGHT_SCORE_DIVISOR)
+    + trickPoints;
+
+  const totalScore = Math.floor(baseScore * (crashed ? 1 : groupieMultiplier));
+  const moneyEarned = totalScore;
+
+  return {
+    distance: Math.floor(distance),
+    maxHeight: Math.floor(maxHeight),
+    trickPoints,
+    crashed,
+    groupiesLost,
+    moneyEarned,
+    totalScore,
+  };
+}
+
+// --- Upgrade purchase ---
+
+export function purchaseUpgrade(
+  upgrades: PlayerUpgrades,
+  money: number,
+  upgradeId: string,
+): { upgrades: PlayerUpgrades; money: number; success: boolean } {
+  const next = { ...upgrades };
+  let cost = 0;
+  let success = false;
+
+  const [category, indexStr] = upgradeId.split('_');
+  const index = parseInt(indexStr, 10);
+
+  const handlers: Record<string, () => void> = {
+    wheels: () => {
+      if (index > next.wheels && index < WHEEL_UPGRADES.tiers.length) {
+        cost = WHEEL_UPGRADES.tiers[index].cost;
+        if (money >= cost) { next.wheels = index; success = true; }
+      }
+    },
+    rockets: () => {
+      if (index > next.rockets && index < ROCKET_UPGRADES.tiers.length) {
+        cost = ROCKET_UPGRADES.tiers[index].cost;
+        if (money >= cost) { next.rockets = index; success = true; }
+      }
+    },
+    armor: () => {
+      if (index > next.armor && index < ARMOR_UPGRADES.tiers.length) {
+        cost = ARMOR_UPGRADES.tiers[index].cost;
+        if (money >= cost) { next.armor = index; success = true; }
+      }
+    },
+    trick: () => {
+      const trick = TRICK_DEFS[index];
+      if (!trick) return;
+      const key = trick.id as keyof Pick<PlayerUpgrades, 'handstand' | 'superman' | 'backflip'>;
+      if (!next[key]) {
+        cost = trick.cost;
+        if (money >= cost) { next[key] = true; success = true; }
+      }
+    },
+    groupie: () => {
+      if (next.groupies < 3) {
+        cost = GROUPIE_COSTS[next.groupies];
+        if (money >= cost) { next.groupies++; success = true; }
+      }
+    },
+  };
+
+  handlers[category]?.();
+
+  return {
+    upgrades: next,
+    money: success ? money - cost : money,
+    success,
+  };
+}

--- a/src/components/game/shopping-cart-hero/types.ts
+++ b/src/components/game/shopping-cart-hero/types.ts
@@ -1,0 +1,98 @@
+// ============================================================================
+// Shopping Cart Hero — Type Definitions
+// ============================================================================
+
+export type GamePhase = 'menu' | 'shop' | 'run' | 'launch' | 'flight' | 'landing' | 'results';
+
+export type UpgradeCategory = 'wheels' | 'rockets' | 'armor' | 'tricks' | 'groupies';
+
+export interface Vec2 {
+  x: number;
+  y: number;
+}
+
+export interface CartState {
+  pos: Vec2;
+  vel: Vec2;
+  angle: number;           // radians
+  angularVel: number;
+  onGround: boolean;
+  crashed: boolean;
+  inCart: boolean;          // stickman jumped into cart
+  rocketFuel: number;      // remaining rocket frames
+  rocketActive: boolean;
+  bounceCount: number;
+  rolling: boolean;
+}
+
+export interface RunnerState {
+  pos: Vec2;
+  speed: number;
+  frame: number;           // animation frame
+  passedMarker1: boolean;
+  passedMarker2: boolean;
+}
+
+export interface TrickState {
+  totalRotation: number;   // accumulated rotation in current direction
+  flipsCompleted: number;
+  handstandActive: boolean;
+  handstandFrames: number;
+  supermanActive: boolean;
+  supermanFrames: number;
+  trickPoints: number;
+  comboText: string;
+  comboTimer: number;
+}
+
+export interface UpgradeTier {
+  name: string;
+  cost: number;
+  description: string;
+}
+
+export interface UpgradeDef {
+  category: UpgradeCategory;
+  tiers: UpgradeTier[];
+}
+
+export interface PlayerUpgrades {
+  wheels: number;          // tier index (0 = default)
+  rockets: number;
+  armor: number;
+  handstand: boolean;
+  superman: boolean;
+  backflip: boolean;
+  groupies: number;        // 0-3
+}
+
+export interface RunResult {
+  distance: number;
+  maxHeight: number;
+  trickPoints: number;
+  crashed: boolean;
+  groupiesLost: number;
+  moneyEarned: number;
+  totalScore: number;
+}
+
+export interface GameState {
+  phase: GamePhase;
+  money: number;
+  highScore: number;
+  totalRuns: number;
+  upgrades: PlayerUpgrades;
+  cart: CartState;
+  runner: RunnerState;
+  tricks: TrickState;
+  lastResult: RunResult | null;
+  cameraX: number;         // horizontal scroll offset
+  groundY: number;         // ground level at current camera position
+}
+
+export interface InputKeys {
+  left: boolean;
+  right: boolean;
+  up: boolean;
+  down: boolean;
+}

--- a/src/components/techie/TechieContentViewer.tsx
+++ b/src/components/techie/TechieContentViewer.tsx
@@ -15,6 +15,7 @@ const CookieClickerGame = lazy(() => import("@/components/game/cookie-clicker").
 const AgarGame = lazy(() => import("@/components/game/agar").then(m => ({ default: m.AgarGame })))
 const MafiaWars = lazy(() => import("@/components/game/mafia-wars"))
 const PokemonGame = lazy(() => import("@/components/game/pokemon").then(m => ({ default: m.PokemonGame })))
+const ShoppingCartHeroGame = lazy(() => import("@/components/game/shopping-cart-hero").then(m => ({ default: m.ShoppingCartHeroGame })))
 
 interface TechieContentViewerProps {
   tab: TechieTab | null
@@ -376,6 +377,7 @@ export function TechieContentViewer({ tab, onEditorChange, onRunCode, editorSett
     "game-agar": <GameLoader><AgarGame /></GameLoader>,
     "game-mafia-wars": <GameLoader><MafiaWars /></GameLoader>,
     "game-pokemon": <GameLoader><PokemonGame /></GameLoader>,
+    "game-shopping-cart-hero": <GameLoader><ShoppingCartHeroGame /></GameLoader>,
   }
 
   if (contentKey in gameMap) return <>{gameMap[contentKey]}</>

--- a/src/components/techie/techie-data.ts
+++ b/src/components/techie/techie-data.ts
@@ -34,6 +34,7 @@ export const fileTree: FileNode[] = [
           { name: "agar.exe", type: "file", contentKey: "game-agar" },
           { name: "mafia-wars.exe", type: "file", contentKey: "game-mafia-wars" },
           { name: "pokemon.exe", type: "file", contentKey: "game-pokemon" },
+          { name: "shopping-cart-hero.exe", type: "file", contentKey: "game-shopping-cart-hero" },
         ],
       },
       { name: ".env", type: "file", contentKey: "hidden-env", hidden: true },

--- a/src/components/techie/terminal/terminal-commands.ts
+++ b/src/components/techie/terminal/terminal-commands.ts
@@ -203,6 +203,7 @@ const run: CommandHandler = (args, ctx) => {
     agar: { contentKey: "game-agar", fileName: "agar.exe" },
     "mafia-wars": { contentKey: "game-mafia-wars", fileName: "mafia-wars.exe" },
     pokemon: { contentKey: "game-pokemon", fileName: "pokemon.exe" },
+    "shopping-cart-hero": { contentKey: "game-shopping-cart-hero", fileName: "shopping-cart-hero.exe" },
   }
 
   const game = gameKeys[gameName]

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -154,6 +154,21 @@ const games: Game[] = [
     yearPlayed: "1996-2003",
     funFact: "I started with Pokemon Red and a Charmander. Brock was brutal without a water type.",
     features: ["151 Pokemon with accurate stats", "Full battle system with type chart", "8 Gym Leaders + Elite Four", "Wild encounters and catching", "Save/Load system", "Mobile touch controls"]
+  },
+  {
+    id: "shopping-cart-hero",
+    title: "Shopping Cart Hero",
+    description: "Launch a shopping cart off a ramp and fly as far as possible!",
+    longDescription: "A faithful recreation of the classic 2009 Flash game. Run down a hill, jump into a shopping cart, launch off a ramp, perform tricks mid-air, and earn money to buy upgrades. Features rockets, armor, groupie multipliers, and trick combos.",
+    thumbnail: "/game-shopping-cart.svg",
+    category: "arcade",
+    link: "/shopping-cart-hero",
+    externalLink: "https://www.crazygames.com/game/shopping-cart-hero",
+    isExternal: false,
+    isBuiltIn: true,
+    yearPlayed: "2009-2011",
+    funFact: "The original was a Flash game I played endlessly during class. The physics of crashing was always funnier than landing safely.",
+    features: ["Physics-based launch and flight", "Upgrade shop (wheels, rockets, armor)", "Trick system (handstands, flips, superman)", "Groupie score multipliers", "Procedural stickman animation", "High score tracking"]
   }
 ]
 


### PR DESCRIPTION
## Summary
- Canvas-based recreation of the classic 2009 Flash game Shopping Cart Hero
- Full gameplay loop: run down hill → jump into cart → launch off ramp → fly with tricks → land → earn money → buy upgrades → repeat
- Physics simulation with gravity, momentum, rotation, bounce, and drag
- 5 upgrade categories: Wheels (4 tiers), Rockets (4 tiers), Armor (4 tiers), Tricks (3 types), Groupies (3 slots)
- Shop UI with category tabs and upgrade cards
- Results screen with score breakdown and groupie multiplier
- localStorage persistence for money, upgrades, and high scores

## New Files
- `src/components/game/shopping-cart-hero/types.ts` — TypeScript interfaces
- `src/components/game/shopping-cart-hero/constants.ts` — Physics tuning, upgrade definitions
- `src/components/game/shopping-cart-hero/physics.ts` — Physics engine
- `src/components/game/shopping-cart-hero/renderer.ts` — Canvas rendering
- `src/components/game/shopping-cart-hero/shop.ts` — Score calculation and shop logic
- `src/components/game/shopping-cart-hero/index.tsx` — Main game component

## Integration
- Route: `/shopping-cart-hero` in AppRoutes.tsx
- Games page entry in Games.tsx
- Terminal command in terminal-commands.ts
- Virtual filesystem entry in techie-data.ts

## Test Plan
- [x] `npm run build` passes with zero errors
- [x] Navigate to `/shopping-cart-hero`, title screen renders
- [x] Shop UI displays all upgrade categories with prices
- [x] Run phase: holding RIGHT accelerates stickman down hill
- [x] Launch phase: hitting UP at marker jumps into cart, ramp launches
- [x] Flight phase: LEFT/RIGHT rotate cart, tricks activate with correct keys
- [x] Landing phase: good landing bounces, bad angle crashes
- [x] Results screen shows distance, height, tricks, money earned
- [x] Upgrades persist across runs via localStorage
- [x] Terminal `run shopping-cart-hero` works in techie mode
- [x] Games page shows Shopping Cart Hero entry