### PR TITLE
Add local profile system for game saves

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { GamificationProvider } from "@/components/providers/GamificationProvide
 import { SmoothScrollProvider } from "@/components/providers/SmoothScrollProvider"
 import { BossProvider } from "@/context/boss-context"
 import { AuthProvider } from "@/context/auth-context"
+import { ProfileProvider } from "@/context/profile-context"
 import { ModeProvider, useMode } from "@/context/mode-context"
 import { CreatureLayer } from "@/components/game/CreatureLayer"
 import { CustomCursor } from "@/components/ui/CustomCursor"
@@ -105,11 +106,13 @@ function App() {
       <GamificationProvider>
         <BossProvider>
           <AuthProvider>
-            <BrowserRouter>
-              <ModeProvider>
-                <AppShell />
-              </ModeProvider>
-            </BrowserRouter>
+            <ProfileProvider>
+              <BrowserRouter>
+                <ModeProvider>
+                  <AppShell />
+                </ModeProvider>
+              </BrowserRouter>
+            </ProfileProvider>
           </AuthProvider>
         </BossProvider>
       </GamificationProvider>

--- a/src/components/profile/ProfileSelector.tsx
+++ b/src/components/profile/ProfileSelector.tsx
@@ -1,0 +1,207 @@
+// ============================================================================
+// Profile Selector — Modal for choosing/creating local profiles
+// ============================================================================
+
+import { useState } from 'react';
+import { useProfile, type UserProfile } from '@/context/profile-context';
+
+const AVATAR_OPTIONS = ['🎮', '🕹️', '👾', '🎯', '🏆', '⚡', '🔥', '💎', '🌟', '🎪', '🐉', '🦊'];
+
+interface ProfileSelectorProps {
+  onSelect: (profile: UserProfile) => void;
+  onCancel?: () => void;
+}
+
+export function ProfileSelector({ onSelect, onCancel }: ProfileSelectorProps) {
+  const { profiles, activeProfile, createProfile, switchProfile, deleteProfile } = useProfile();
+  const [mode, setMode] = useState<'select' | 'create'>(profiles.length === 0 ? 'create' : 'select');
+  const [newName, setNewName] = useState('');
+  const [selectedAvatar, setSelectedAvatar] = useState(AVATAR_OPTIONS[0]);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  const handleCreate = () => {
+    const profile = createProfile(newName, selectedAvatar);
+    onSelect(profile);
+  };
+
+  const handleSelect = (profile: UserProfile) => {
+    switchProfile(profile.id);
+    onSelect(profile);
+  };
+
+  const handleDelete = (id: string) => {
+    deleteProfile(id);
+    setConfirmDelete(null);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4">
+      <div className="bg-neutral-900 border border-neutral-700 rounded-xl max-w-md w-full p-6 shadow-2xl">
+        {/* Header */}
+        <div className="text-center mb-6">
+          <h2 className="text-xl font-bold text-white">
+            {mode === 'create' ? 'Create Profile' : 'Choose Profile'}
+          </h2>
+          <p className="text-neutral-400 text-sm mt-1">
+            Local profiles — cloud save & sync coming soon!
+          </p>
+        </div>
+
+        {mode === 'select' ? (
+          <>
+            {/* Existing profiles */}
+            <div className="space-y-2 mb-4">
+              {profiles.map(profile => (
+                <div
+                  key={profile.id}
+                  className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-colors
+                    ${profile.id === activeProfile?.id
+                      ? 'bg-blue-600/20 border border-blue-500/40'
+                      : 'bg-neutral-800 border border-transparent hover:border-neutral-600'
+                    }`}
+                  onClick={() => handleSelect(profile)}
+                >
+                  <span className="text-2xl">{profile.avatar}</span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-white font-medium truncate">{profile.name}</p>
+                    <p className="text-neutral-500 text-xs">
+                      Created {new Date(profile.createdAt).toLocaleDateString()}
+                      {Object.keys(profile.gameData).length > 0 &&
+                        ` · ${Object.keys(profile.gameData).length} game${Object.keys(profile.gameData).length === 1 ? '' : 's'} saved`
+                      }
+                    </p>
+                  </div>
+
+                  {/* Delete button */}
+                  {confirmDelete === profile.id ? (
+                    <div className="flex gap-1">
+                      <button
+                        onClick={(e) => { e.stopPropagation(); handleDelete(profile.id); }}
+                        className="px-2 py-1 bg-red-600 text-white text-xs rounded hover:bg-red-500"
+                      >
+                        Yes
+                      </button>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); setConfirmDelete(null); }}
+                        className="px-2 py-1 bg-neutral-700 text-white text-xs rounded hover:bg-neutral-600"
+                      >
+                        No
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); setConfirmDelete(profile.id); }}
+                      className="text-neutral-600 hover:text-red-400 text-sm transition-colors p-1"
+                      title="Delete profile"
+                    >
+                      ✕
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            {/* Create new button */}
+            {profiles.length < 5 && (
+              <button
+                onClick={() => setMode('create')}
+                className="w-full p-3 border-2 border-dashed border-neutral-700 rounded-lg text-neutral-400
+                  hover:border-neutral-500 hover:text-neutral-300 transition-colors text-sm"
+              >
+                + Create New Profile
+              </button>
+            )}
+          </>
+        ) : (
+          <>
+            {/* Create form */}
+            <div className="space-y-4">
+              {/* Name input */}
+              <div>
+                <label className="block text-neutral-400 text-sm mb-1">Name</label>
+                <input
+                  type="text"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="Player"
+                  maxLength={20}
+                  className="w-full px-3 py-2 bg-neutral-800 border border-neutral-700 rounded-lg
+                    text-white placeholder:text-neutral-600 focus:outline-none focus:border-blue-500"
+                  autoFocus
+                  onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+                />
+              </div>
+
+              {/* Avatar picker */}
+              <div>
+                <label className="block text-neutral-400 text-sm mb-2">Avatar</label>
+                <div className="grid grid-cols-6 gap-2">
+                  {AVATAR_OPTIONS.map(emoji => (
+                    <button
+                      key={emoji}
+                      onClick={() => setSelectedAvatar(emoji)}
+                      className={`text-2xl p-2 rounded-lg transition-colors
+                        ${emoji === selectedAvatar
+                          ? 'bg-blue-600/30 border border-blue-500'
+                          : 'bg-neutral-800 border border-transparent hover:border-neutral-600'
+                        }`}
+                    >
+                      {emoji}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Actions */}
+              <div className="flex gap-2">
+                <button
+                  onClick={handleCreate}
+                  className="flex-1 py-2 bg-blue-600 text-white rounded-lg font-medium
+                    hover:bg-blue-500 transition-colors"
+                >
+                  Create
+                </button>
+                {profiles.length > 0 && (
+                  <button
+                    onClick={() => setMode('select')}
+                    className="px-4 py-2 bg-neutral-800 text-neutral-300 rounded-lg
+                      hover:bg-neutral-700 transition-colors"
+                  >
+                    Back
+                  </button>
+                )}
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Cancel */}
+        {onCancel && (
+          <button
+            onClick={onCancel}
+            className="w-full mt-4 py-2 text-neutral-500 hover:text-neutral-300 text-sm transition-colors"
+          >
+            Play without profile
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// --- Compact profile badge for in-game display ---
+
+export function ProfileBadge() {
+  const { activeProfile } = useProfile();
+
+  if (!activeProfile) return null;
+
+  return (
+    <div className="flex items-center gap-1.5 px-2 py-1 bg-neutral-800/80 rounded-md border border-neutral-700/50">
+      <span className="text-sm">{activeProfile.avatar}</span>
+      <span className="text-xs text-neutral-300 font-medium truncate max-w-[80px]">
+        {activeProfile.name}
+      </span>
+    </div>
+  );
+}

--- a/src/context/profile-context.tsx
+++ b/src/context/profile-context.tsx
@@ -1,0 +1,165 @@
+// ============================================================================
+// Local Profile System — Context & Provider
+// ============================================================================
+// localStorage-based user profiles for game save persistence.
+// Full cloud login/sync planned for future release.
+
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+
+// --- Types ---
+
+export interface UserProfile {
+  id: string;
+  name: string;
+  avatar: string;        // emoji
+  createdAt: number;
+  gameData: Record<string, unknown>;
+}
+
+interface ProfileContextValue {
+  profiles: UserProfile[];
+  activeProfile: UserProfile | null;
+  createProfile: (name: string, avatar: string) => UserProfile;
+  switchProfile: (id: string) => void;
+  deleteProfile: (id: string) => void;
+  clearActiveProfile: () => void;
+  saveGameData: (gameId: string, data: unknown) => void;
+  loadGameData: <T>(gameId: string) => T | null;
+}
+
+// --- Constants ---
+
+const STORAGE_KEY = 'portfolio-profiles';
+const ACTIVE_PROFILE_KEY = 'portfolio-active-profile';
+const MAX_PROFILES = 5;
+
+// --- Storage helpers ---
+
+function loadProfiles(): UserProfile[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveProfiles(profiles: UserProfile[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));
+}
+
+function loadActiveId(): string | null {
+  return localStorage.getItem(ACTIVE_PROFILE_KEY);
+}
+
+function saveActiveId(id: string | null): void {
+  if (id) {
+    localStorage.setItem(ACTIVE_PROFILE_KEY, id);
+  } else {
+    localStorage.removeItem(ACTIVE_PROFILE_KEY);
+  }
+}
+
+function generateId(): string {
+  return `profile_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// --- Context ---
+
+const ProfileContext = createContext<ProfileContextValue | null>(null);
+
+// --- Provider ---
+
+export function ProfileProvider({ children }: { children: ReactNode }) {
+  const [profiles, setProfiles] = useState<UserProfile[]>(loadProfiles);
+  const [activeId, setActiveId] = useState<string | null>(loadActiveId);
+
+  const activeProfile = profiles.find(p => p.id === activeId) ?? null;
+
+  const createProfile = useCallback((name: string, avatar: string): UserProfile => {
+    const profile: UserProfile = {
+      id: generateId(),
+      name: name.trim() || 'Player',
+      avatar,
+      createdAt: Date.now(),
+      gameData: {},
+    };
+
+    setProfiles(prev => {
+      const next = [...prev, profile].slice(-MAX_PROFILES);
+      saveProfiles(next);
+      return next;
+    });
+
+    setActiveId(profile.id);
+    saveActiveId(profile.id);
+
+    return profile;
+  }, []);
+
+  const switchProfile = useCallback((id: string) => {
+    setActiveId(id);
+    saveActiveId(id);
+  }, []);
+
+  const deleteProfile = useCallback((id: string) => {
+    setProfiles(prev => {
+      const next = prev.filter(p => p.id !== id);
+      saveProfiles(next);
+      return next;
+    });
+
+    if (activeId === id) {
+      setActiveId(null);
+      saveActiveId(null);
+    }
+  }, [activeId]);
+
+  const clearActiveProfile = useCallback(() => {
+    setActiveId(null);
+    saveActiveId(null);
+  }, []);
+
+  const saveGameData = useCallback((gameId: string, data: unknown) => {
+    if (!activeId) return;
+
+    setProfiles(prev => {
+      const next = prev.map(p => {
+        if (p.id !== activeId) return p;
+        return { ...p, gameData: { ...p.gameData, [gameId]: data } };
+      });
+      saveProfiles(next);
+      return next;
+    });
+  }, [activeId]);
+
+  const loadGameData = useCallback(<T,>(gameId: string): T | null => {
+    if (!activeProfile) return null;
+    return (activeProfile.gameData[gameId] as T) ?? null;
+  }, [activeProfile]);
+
+  return (
+    <ProfileContext.Provider
+      value={{
+        profiles,
+        activeProfile,
+        createProfile,
+        switchProfile,
+        deleteProfile,
+        clearActiveProfile,
+        saveGameData,
+        loadGameData,
+      }}
+    >
+      {children}
+    </ProfileContext.Provider>
+  );
+}
+
+// --- Hook ---
+
+export function useProfile(): ProfileContextValue {
+  const ctx = useContext(ProfileContext);
+  if (!ctx) throw new Error('useProfile must be used within ProfileProvider');
+  return ctx;
+}

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -208,35 +208,35 @@ export function Games() {
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.05 }}
-            className="mb-6 flex items-center justify-between gap-3 p-3 bg-neutral-900/50 rounded-lg border border-neutral-800"
+            className="mb-6 flex flex-wrap items-center justify-between gap-3 p-3 bg-background/50 rounded-lg border border-border"
           >
             {activeProfile ? (
               <>
                 <div className="flex items-center gap-2">
                   <span className="text-lg">{activeProfile.avatar}</span>
                   <div>
-                    <span className="text-sm font-medium text-white">{activeProfile.name}</span>
-                    <span className="text-xs text-neutral-500 ml-2">
-                      {Object.keys(activeProfile.gameData).length} game{Object.keys(activeProfile.gameData).length === 1 ? '' : 's'} saved
+                    <span className="text-sm font-medium text-foreground">{activeProfile.name}</span>
+                    <span className="text-xs text-muted-foreground ml-2">
+                      {(() => { const count = Object.keys(activeProfile.gameData).length; return `${count} game${count === 1 ? '' : 's'} saved`; })()}
                     </span>
                   </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-[10px] text-neutral-500">Playing locally — full account system coming soon</span>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-[10px] text-muted-foreground">Playing locally — full account system coming soon</span>
                   <Button variant="outline" size="sm" onClick={() => setShowProfileSelector(true)} className="text-xs h-7">
                     Switch
                   </Button>
-                  <Button variant="ghost" size="sm" onClick={clearActiveProfile} className="text-xs h-7 text-neutral-500">
+                  <Button variant="ghost" size="sm" onClick={clearActiveProfile} className="text-xs h-7 text-muted-foreground">
                     Sign Out
                   </Button>
                 </div>
               </>
             ) : (
               <>
-                <div className="flex items-center gap-2 text-sm text-neutral-400">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
                   <User className="w-4 h-4" />
                   <span>Create a profile to save your game progress</span>
-                  <span className="text-[10px] text-neutral-500 ml-1">— cloud sync coming soon</span>
+                  <span className="text-[10px] text-muted-foreground ml-1">— cloud sync coming soon</span>
                 </div>
                 <Button size="sm" onClick={() => setShowProfileSelector(true)} className="text-xs h-7">
                   Create Profile

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react"
 import { motion } from "framer-motion"
 import { Link } from "react-router-dom"
-import { ArrowLeft, ExternalLink, Gamepad2, Trophy, Star, Clock, Play, Code, Sparkles } from "lucide-react"
+import { ArrowLeft, ExternalLink, Gamepad2, Trophy, Star, Clock, Play, Code, Sparkles, User } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import { useProfile } from "@/context/profile-context"
+import { ProfileSelector } from "@/components/profile/ProfileSelector"
 
 interface Game {
   id: string
@@ -167,6 +169,8 @@ const categoryColors = {
 export function Games() {
   const [selectedGame, setSelectedGame] = useState<Game | null>(null)
   const [filter, setFilter] = useState<"all" | "built-in" | "classic" | "arcade" | "strategy" | "original">("all")
+  const [showProfileSelector, setShowProfileSelector] = useState(false)
+  const { activeProfile, clearActiveProfile } = useProfile()
 
   const filteredGames = filter === "all"
     ? games
@@ -198,6 +202,56 @@ export function Games() {
               with my grandfather to building my own games today - here are the ones that shaped me.
             </p>
           </motion.div>
+
+          {/* Profile banner */}
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.05 }}
+            className="mb-6 flex items-center justify-between gap-3 p-3 bg-neutral-900/50 rounded-lg border border-neutral-800"
+          >
+            {activeProfile ? (
+              <>
+                <div className="flex items-center gap-2">
+                  <span className="text-lg">{activeProfile.avatar}</span>
+                  <div>
+                    <span className="text-sm font-medium text-white">{activeProfile.name}</span>
+                    <span className="text-xs text-neutral-500 ml-2">
+                      {Object.keys(activeProfile.gameData).length} game{Object.keys(activeProfile.gameData).length === 1 ? '' : 's'} saved
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-[10px] text-neutral-500">Playing locally — full account system coming soon</span>
+                  <Button variant="outline" size="sm" onClick={() => setShowProfileSelector(true)} className="text-xs h-7">
+                    Switch
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={clearActiveProfile} className="text-xs h-7 text-neutral-500">
+                    Sign Out
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="flex items-center gap-2 text-sm text-neutral-400">
+                  <User className="w-4 h-4" />
+                  <span>Create a profile to save your game progress</span>
+                  <span className="text-[10px] text-neutral-500 ml-1">— cloud sync coming soon</span>
+                </div>
+                <Button size="sm" onClick={() => setShowProfileSelector(true)} className="text-xs h-7">
+                  Create Profile
+                </Button>
+              </>
+            )}
+          </motion.div>
+
+          {/* Profile selector modal */}
+          {showProfileSelector && (
+            <ProfileSelector
+              onSelect={() => setShowProfileSelector(false)}
+              onCancel={() => setShowProfileSelector(false)}
+            />
+          )}
 
           {/* Filter */}
           <motion.div


### PR DESCRIPTION
## Summary
- localStorage-based user profile system for game save persistence
- Profile selector modal with create/switch/delete functionality
- Max 5 profiles per device, each with avatar (emoji) and game data storage
- Profile banner on Games page showing active profile info
- "Cloud save & sync coming soon" messaging in UI
- ProfileProvider context wraps the app for global access

## New Files
- `src/context/profile-context.tsx` — ProfileProvider, useProfile hook, UserProfile type
- `src/components/profile/ProfileSelector.tsx` — Modal UI + ProfileBadge component

## Modified Files
- `src/App.tsx` — Wrapped with ProfileProvider
- `src/pages/Games.tsx` — Added profile banner, selector, and imports

## Test Plan
- [x] `npm run build` passes with zero errors
- [x] Games page shows "Create a profile" banner when no profile exists
- [x] Click "Create Profile" opens selector modal
- [x] Create profile with name and avatar emoji
- [x] Profile banner shows active profile name, avatar, and saved game count
- [x] "Switch" button opens selector to choose different profile
- [x] "Sign Out" clears active profile
- [x] Delete profile with confirmation
- [x] Max 5 profiles enforced
- [x] Profiles persist across page reloads via localStorage
- [x] "Cloud save coming soon" messaging visible in selector and banner