### PR TITLE
Prevent canceling forced Pokemon switch

### DIFF
--- a/src/components/game/pokemon/hooks/useBattle.ts
+++ b/src/components/game/pokemon/hooks/useBattle.ts
@@ -86,6 +86,9 @@ export function useBattle() {
   const cancel = useCallback(() => {
     setBattleState(prev => {
       if (!prev) return null;
+      if (prev.phase === 'switch_select' && prev.playerActive.pokemon.currentHp <= 0) {
+        return prev;
+      }
       if (prev.phase === 'move_select' || prev.phase === 'item_select' || prev.phase === 'switch_select') {
         return {
           ...prev,


### PR DESCRIPTION
## Summary\n- block cancel/back action during forced switch when active Pokemon is fainted\n\n## Testing\n- not run (ESLint failing locally: TypeError in @typescript-eslint/utils)