### PR TITLE
Reset Pokemon battle menu selection on phase change

### DIFF
--- a/src/components/game/pokemon/components/BattleUI.tsx
+++ b/src/components/game/pokemon/components/BattleUI.tsx
@@ -40,6 +40,10 @@ export default function BattleUI({
 }: BattleUIProps) {
   const menuIndex = useRef(0);
 
+  useEffect(() => {
+    menuIndex.current = 0;
+  }, [state.phase]);
+
   // Render battle scene to canvas
   useEffect(() => {
     const ctx = canvasRef.current?.getContext('2d');


### PR DESCRIPTION
## Summary\n- reset battle menu cursor when phase changes to avoid stale selection\n\n## Testing\n- not run (ESLint failing locally: TypeError in @typescript-eslint/utils)