### PR TITLE
Add voice navigation for new games

### DIFF
--- a/src/components/voice-assistant/AIAssistant.tsx
+++ b/src/components/voice-assistant/AIAssistant.tsx
@@ -434,7 +434,7 @@ export function AIAssistant() {
                 contents: [{
                   role: "user",
                   parts: [{ text: `Analyze this user request and determine if they want to navigate somewhere.
-Available pages: games, projects, philosophy, inventions, blog, social, tetris, snake, tanks, cookie-clicker, chess, agar, home
+Available pages: games, projects, philosophy, inventions, blog, social, falling-blocks, tetris, snake, tanks, cookie-clicker, chess, agar, pokemon, shopping-cart-hero, mafia-wars, home
 Available sections on home: hero, about, skills, experience, projects, contact
 
 User request: "${trimmedInput}"

--- a/src/services/voice-stocks/navigationService.ts
+++ b/src/services/voice-stocks/navigationService.ts
@@ -20,6 +20,9 @@ const ROUTE_MAPPINGS: Record<string, { route: string; aliases: string[] }> = {
   'cookie-clicker': { route: '/cookie-clicker', aliases: ['cookie', 'clicker', 'cookie game'] },
   chess: { route: '/chess', aliases: ['chess game'] },
   agar: { route: '/agar', aliases: ['agar.io', 'agar game', 'agario'] },
+  pokemon: { route: '/pokemon', aliases: ['pokemon game', 'poke', 'pokémon'] },
+  'shopping-cart-hero': { route: '/shopping-cart-hero', aliases: ['shopping cart hero', 'cart hero', 'shopping cart'] },
+  'mafia-wars': { route: '/mafia-wars', aliases: ['mafia wars', 'mafia', 'mob'] },
   home: { route: '/', aliases: ['main', 'start', 'beginning', 'top'] },
 };
 

--- a/src/services/voice-stocks/voiceCommandRouter.ts
+++ b/src/services/voice-stocks/voiceCommandRouter.ts
@@ -147,6 +147,10 @@ export class VoiceCommandRouter {
 **Navigation:**
 - "Go to projects" - Navigate to a page
 - "Go to games" - Open the games section
+- "Go to falling blocks" - Open Falling Blocks
+- "Go to pokemon" - Open the Pokemon game
+- "Go to shopping cart hero" - Open the Shopping Cart Hero game
+- "Go to mafia wars" - Open the Mafia Wars game
 - "Show me skills" - Jump to skills section
 - "Scroll down/up" - Scroll the page
 


### PR DESCRIPTION
## Summary

- Register Pokemon, Shopping Cart Hero, and Mafia Wars in the voice navigation route mappings with relevant aliases
- Add Falling Blocks to the AI navigation intent prompt (was missing despite having a route mapping)
- Add help text entries for all four new games so users know they can navigate by saying "Go to pokemon", etc.

## Files Changed

| File | Changes |
|------|---------|
| `src/components/voice-assistant/AIAssistant.tsx` | Add new game names to AI intent available pages list |
| `src/services/voice-stocks/navigationService.ts` | Add pokemon, shopping-cart-hero, mafia-wars route mappings with aliases |
| `src/services/voice-stocks/voiceCommandRouter.ts` | Add help text lines for falling blocks, pokemon, shopping cart hero, mafia wars |

## Test plan

- [ ] Say "Go to pokemon" and verify navigation to `/pokemon`
- [ ] Say "Go to shopping cart hero" and verify navigation to `/shopping-cart-hero`
- [ ] Say "Go to mafia wars" and verify navigation to `/mafia-wars`
- [ ] Say "Go to falling blocks" and verify navigation to `/game`
- [ ] Alias variants work ("mafia", "cart hero", "poke")
- [ ] Help text shows the new game navigation examples