### PR TITLE
Add AI & LLM Development section and dedicated page

### DIFF
--- a/src/components/sections/AIExperience.tsx
+++ b/src/components/sections/AIExperience.tsx
@@ -1,0 +1,206 @@
+import { useState, useEffect, useRef } from "react"
+import { motion } from "framer-motion"
+import { Link } from "react-router-dom"
+import { Brain, Shield, Mic, ArrowRight, Sparkles, Terminal, Layers } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { aiStats } from "@/data/ai-development"
+
+function AnimatedCounter({ target, suffix = "" }: { target: string; suffix?: string }) {
+  const [count, setCount] = useState(0)
+  const ref = useRef<HTMLDivElement>(null)
+  const [hasAnimated, setHasAnimated] = useState(false)
+
+  const numericValue = parseInt(target.replace(/[^0-9.]/g, ""), 10)
+  const isDecimal = target.includes(".")
+  const decimalValue = isDecimal ? parseFloat(target.replace(/[^0-9.]/g, "")) : numericValue
+
+  useEffect(() => {
+    if (hasAnimated || !ref.current) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !hasAnimated) {
+          setHasAnimated(true)
+          const duration = 1500
+          const startTime = performance.now()
+
+          const animate = (currentTime: number) => {
+            const elapsed = currentTime - startTime
+            const progress = Math.min(elapsed / duration, 1)
+            const eased = 1 - Math.pow(1 - progress, 3)
+
+            if (isDecimal) {
+              setCount(Math.round(eased * decimalValue * 10) / 10)
+            } else {
+              setCount(Math.round(eased * numericValue))
+            }
+
+            if (progress < 1) {
+              requestAnimationFrame(animate)
+            }
+          }
+
+          requestAnimationFrame(animate)
+        }
+      },
+      { threshold: 0.3 }
+    )
+
+    observer.observe(ref.current)
+    return () => observer.disconnect()
+  }, [hasAnimated, numericValue, decimalValue, isDecimal])
+
+  const displaySuffix = target.includes("+") ? "+" : ""
+
+  return (
+    <div ref={ref} className="text-3xl md:text-4xl font-bold text-primary">
+      {isDecimal ? count.toFixed(1) : count}
+      {displaySuffix}{suffix}
+    </div>
+  )
+}
+
+const highlightCards = [
+  {
+    icon: Layers,
+    title: "Apps That Build Apps",
+    description: "A 5-layer recursive ecosystem where prompts generate other prompts, specifications become code, and quality gates ensure production readiness across 77+ projects.",
+    gradient: "from-amber-500/20 to-orange-500/20",
+    border: "border-amber-500/30",
+    iconColor: "text-amber-400",
+  },
+  {
+    icon: Terminal,
+    title: "10 Battle-Tested Prompt Patterns",
+    description: "Reusable patterns forged in production: two-phase initialization, continuation-first research, mass feature builds, 3-pass code reviews, and branch chaining.",
+    gradient: "from-blue-500/20 to-cyan-500/20",
+    border: "border-blue-500/30",
+    iconColor: "text-blue-400",
+  },
+  {
+    icon: Mic,
+    title: "Voice-First AI (<500ms)",
+    description: "Full duplex conversation via PersonaPlex. Not turn-based chat, but natural conversation with interruption support, back-channeling, and smart model routing.",
+    gradient: "from-purple-500/20 to-pink-500/20",
+    border: "border-purple-500/30",
+    iconColor: "text-purple-400",
+  },
+  {
+    icon: Shield,
+    title: "Privacy-First Architecture",
+    description: "7 projects where data never leaves the device. Local LLMs up to 72B parameters, BYOK patterns, AES-256-GCM encryption, zero data retention.",
+    gradient: "from-green-500/20 to-emerald-500/20",
+    border: "border-green-500/30",
+    iconColor: "text-green-400",
+  },
+]
+
+const displayStats = [
+  { ...aiStats[0], suffix: "" },
+  { ...aiStats[1], suffix: "" },
+  { ...aiStats[2], suffix: "" },
+  { ...aiStats[3], suffix: "" },
+]
+
+export function AIExperience() {
+  return (
+    <section id="ai-experience" className="py-20 md:py-32 relative overflow-hidden">
+      {/* Background gradient */}
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-primary/5 to-transparent pointer-events-none" />
+
+      <div className="container max-w-6xl relative z-10">
+        {/* Section Header */}
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-center mb-16"
+        >
+          <Badge variant="secondary" className="mb-4 gap-1.5 px-3 py-1">
+            <Brain className="h-3.5 w-3.5" />
+            20+ Months of Production AI Work
+          </Badge>
+          <h2 className="text-3xl md:text-5xl font-bold mb-4 bg-gradient-to-r from-primary via-purple-500 to-pink-500 bg-clip-text text-transparent">
+            AI & LLM Development
+          </h2>
+          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+            A complete, production-grade system for building software with AI agents.
+            Not experiments. Not demos. Real applications, real users, real engineering standards.
+          </p>
+        </motion.div>
+
+        {/* Stats Row */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ delay: 0.2, duration: 0.6 }}
+          className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-16"
+        >
+          {displayStats.map((stat, i) => (
+            <motion.div
+              key={stat.label}
+              initial={{ opacity: 0, scale: 0.9 }}
+              whileInView={{ opacity: 1, scale: 1 }}
+              viewport={{ once: true }}
+              transition={{ delay: 0.3 + i * 0.1 }}
+              className="text-center p-4 rounded-xl bg-card/50 border border-border/50 backdrop-blur-sm"
+            >
+              <AnimatedCounter target={stat.value} />
+              <div className="text-sm text-muted-foreground mt-1">{stat.label}</div>
+            </motion.div>
+          ))}
+        </motion.div>
+
+        {/* Highlight Cards */}
+        <div className="grid md:grid-cols-2 gap-6 mb-12">
+          {highlightCards.map((card, i) => {
+            const Icon = card.icon
+            return (
+              <motion.div
+                key={card.title}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: 0.2 + i * 0.1 }}
+                className={`p-6 rounded-xl border ${card.border} bg-gradient-to-br ${card.gradient} backdrop-blur-sm hover:scale-[1.02] transition-transform`}
+              >
+                <div className="flex items-start gap-4">
+                  <div className={`p-2.5 rounded-lg bg-background/50 ${card.iconColor}`}>
+                    <Icon className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <h3 className="text-lg font-bold mb-2">{card.title}</h3>
+                    <p className="text-sm text-muted-foreground leading-relaxed">{card.description}</p>
+                  </div>
+                </div>
+              </motion.div>
+            )
+          })}
+        </div>
+
+        {/* CTA */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ delay: 0.6 }}
+          className="text-center"
+        >
+          <Button asChild size="lg" className="gap-2 px-8">
+            <Link to="/ai-development">
+              <Sparkles className="h-4 w-4" />
+              Explore the Full Story
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </Button>
+          <p className="text-sm text-muted-foreground mt-3">
+            11 production AI products, 10 prompt patterns, the complete journey
+          </p>
+        </motion.div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react"
 import { Link, useNavigate, useLocation } from "react-router-dom"
-import { Menu, X, Moon, Sun, User, FolderKanban, Briefcase, Mail, Wrench, Lightbulb, Brain, BookOpen, Share2, Gamepad2, ChevronDown, Download } from "lucide-react"
+import { Menu, X, Moon, Sun, User, FolderKanban, Briefcase, Mail, Wrench, Lightbulb, Brain, BookOpen, Share2, Gamepad2, ChevronDown, Download, Bot } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useTheme } from "@/components/providers/ThemeProvider"
 import { cn } from "@/lib/utils"
@@ -47,6 +47,7 @@ const navStructure = {
       { name: "Skills", path: "/#skills", icon: Wrench },
       { name: "Experience", path: "/#experience", icon: Briefcase },
       { name: "Inventions", path: "/inventions", icon: Lightbulb },
+      { name: "AI Development", path: "/ai-development", icon: Bot },
     ]
   }
 }
@@ -70,6 +71,7 @@ const allNavItems = [
   { name: "Social", path: "/social", icon: Share2 },
   { name: "Philosophy", path: "/philosophy", icon: Brain },
   { name: "Inventions", path: "/inventions", icon: Lightbulb },
+  { name: "AI Development", path: "/ai-development", icon: Bot },
   { name: "Contact", path: "/#contact", icon: Mail },
 ]
 

--- a/src/data/ai-development.ts
+++ b/src/data/ai-development.ts
@@ -93,8 +93,11 @@ export const aiStats: AIStat[] = [
   { label: "Projects with AI Prompts", value: "77+", description: "Each with structured agent prompt infrastructure" },
   { label: "Production AI Products", value: "11", description: "Shipped, working AI-powered applications" },
   { label: "Reusable Prompt Patterns", value: "10", description: "Battle-tested across dozens of projects" },
-  { label: "Claude Code Sessions", value: "273", description: "Consolidated, recoverable development sessions" },
+  { label: "Total AI Sessions", value: "560+", description: "Across Claude, Gemini, Codex, Cursor, and ChatGPT" },
   { label: "Enterprise Prompts", value: "36", description: "Production prompts from client work (836KB)" },
+  { label: "Conversation Data", value: "19.7 GB", description: "Raw AI interaction data across all tools" },
+  { label: "Git Commits", value: "4,442", description: "Across 53 repositories spanning 2019-2026" },
+  { label: "Market Research Reports", value: "11", description: "Full competitive intelligence with validated unit economics" },
   { label: "Test Coverage", value: "97.7%", description: "Research Agent branch coverage" },
 ]
 
@@ -567,11 +570,26 @@ export const gitWorkflow = [
 // ============================================
 
 export const aiTools: AITool[] = [
-  { name: "Claude Code", stats: "273 sessions, 590KB history, 738+ todos", purpose: "Primary development agent for code generation, architecture, debugging, and autonomous multi-phase builds" },
-  { name: "GitHub Copilot", stats: "Multiple versions installed", purpose: "IDE-level code completion and inline suggestions during manual coding" },
-  { name: "Cursor", stats: "24,407 files (~436MB context)", purpose: "AI IDE with full project context awareness for targeted edits" },
-  { name: "Gemini / Google AI", stats: "235MB working data", purpose: "Research, search, and exploration tasks" },
+  { name: "Claude Code CLI", stats: "330 sessions, 9.1 GB data, 4,050 history commands", purpose: "Primary development agent. Largest session: 1.53 GB. Peak: 15 simultaneous instances. Autonomous multi-phase builds with --dangerously-skip-permissions." },
+  { name: "Gemini CLI", stats: "41 sessions, 613 MB brain data", purpose: "Portfolio-specific work (games, visual features). Built Mafia Wars recreation (245 MB session, 10 phases), portfolio rebuild (111 MB, 17 phases). Identical code standards enforced via GEMINI.md." },
+  { name: "OpenAI Codex CLI", stats: "44 sessions, 248 MB, model gpt-5.2-codex", purpose: "Bulk parallel processing. Peak day: 12 sessions in one day across patent-intelligence, TreasureTrail, ChoreChamp, SpecTree, save-a-stray, ink-synthesis." },
+  { name: "Cursor IDE", stats: "49 workspace roots, 2.2 GB data, AI tracking DB", purpose: "AI-native VS Code fork with full project context. MCP integration for Render deployment management." },
+  { name: "GitHub Copilot Chat", stats: "5 versions installed (VS Code + Cursor)", purpose: "IDE-level code completion, inline suggestions, and chat-based assistance during manual coding." },
+  { name: "ChatGPT Desktop", stats: "macOS app with 69 extensions", purpose: "Supplementary research and exploration. Conversation exports backed up to Google Drive." },
+  { name: "Ollama", stats: "5 models, 187 GB+, up to 72B parameters", purpose: "Local model server for privacy-first development. Models: qwen2.5 (7B/32B/72B), dolphin-mistral:7b, qwen2.5-coder:32b." },
 ]
+
+export const toolDiversificationStrategy = `Each AI tool serves a specific role in the workflow:
+- Claude Code: Heavy development, orchestration, multi-phase autonomous builds
+- Gemini CLI: Portfolio work, games, visual features, image generation
+- Codex CLI: Bulk parallel processing of multiple projects simultaneously
+- Cursor: IDE-integrated AI for targeted edits with full project context
+- ChatGPT: Supplementary research and exploration
+- Ollama: Privacy-first local inference, offline development capability`
+
+export const crossAgentVerification = `A recurring methodology: give one AI's output to another AI for independent verification.
+"I gave this prompt to another AI, can you go through and double check they did everything."
+This creates a multi-model quality assurance loop similar to human code review, catching model-specific blind spots.`
 
 export const claudeCodeConfig = `13 configuration files totaling ~101KB of rules and context:
 - Global CLAUDE.md (22KB): Master ruleset for all projects
@@ -580,7 +598,9 @@ export const claudeCodeConfig = `13 configuration files totaling ~101KB of rules
   - Prompt/SDD rules, testing/memories, integration
   - Render infrastructure management
 - Project-specific: Jarvis (5.5KB), Dev Environment (1.7KB)
-- Memory file: Persistent learnings across sessions`
+- Session hooks: auto-logging via session-logger.sh
+- Memory file: Persistent learnings across sessions
+- 378 shell snapshots, 915 debug logs, 842 todo directories`
 
 // ============================================
 // PRACTICAL USE CASES
@@ -694,6 +714,209 @@ export const advancedPatterns = [
   { name: "Granularity Guidelines", description: "User Stories scoped to '~1 week of work', Tasks scoped to '~1 day of work'. Consistent sizing produces predictable AI-generated work items." },
   { name: "Multi-Step Prompt Chains", description: "Sequential prompt chains where each level builds on previous outputs: Epic, then Feature, then User Story, then Task. Progressive refinement at each level." },
 ]
+
+// ============================================
+// FORBIDDEN PATTERNS (Zero-Tolerance Code Standards)
+// ============================================
+
+export interface ForbiddenPattern {
+  category: string
+  severity: string
+  patterns: string[]
+  detection: string
+}
+
+export const forbiddenPatterns: ForbiddenPattern[] = [
+  {
+    category: "TypeScript Violations",
+    severity: "CRITICAL",
+    patterns: ["any", "as any", "@ts-ignore", "@ts-expect-error", "@ts-nocheck", "Function", "Object", "{} as type", "React.FC<{}>", "Promise<any>", "useState() without type"],
+    detection: "grep -rn \":s*any\" --include=\"*.ts\" --include=\"*.tsx\" src/",
+  },
+  {
+    category: "ESLint Violations",
+    severity: "CRITICAL",
+    patterns: ["eslint-disable", "eslint-disable-next-line", "eslint-disable-line"],
+    detection: "grep -rn \"eslint-disable\" --include=\"*.ts\" --include=\"*.tsx\" src/",
+  },
+  {
+    category: "Console Violations",
+    severity: "HIGH",
+    patterns: ["console.log()", "console.error()", "console.warn()", "console.info()"],
+    detection: "grep -rn \"console\\.\" --include=\"*.ts\" --include=\"*.tsx\" src/",
+  },
+  {
+    category: "Empty Implementations",
+    severity: "HIGH",
+    patterns: ["onClick={() => {}}", "onSubmit={() => {}}", "catch(e) {} (swallowed errors)"],
+    detection: "grep -rn \"catch.*{}\" --include=\"*.ts\" --include=\"*.tsx\" src/",
+  },
+  {
+    category: "Comment Violations",
+    severity: "MEDIUM",
+    patterns: ["TODO: without ticket", "FIXME: without ticket", "HACK:", "PLACEHOLDER", "// AI generated this"],
+    detection: "grep -rn \"TODO\\|FIXME\\|HACK\\|PLACEHOLDER\" src/",
+  },
+  {
+    category: "Git Violations",
+    severity: "CRITICAL",
+    patterns: ["Push to main directly", "--force push", "--amend on pushed commits", "Co-Authored-By: Claude", "Generated with Claude Code"],
+    detection: "Branch protection rules + CI pipeline enforcement",
+  },
+]
+
+export const forbiddenPatternsDescription = `A zero-tolerance enforcement system across all 77+ projects. Automated detection via detect_violations.sh with severity levels (CRITICAL/HIGH/MEDIUM). CI pipeline blocks merging if any CRITICAL violation is detected. 185KB TypeScript Strict Mode Checklist with 1,200+ type safety checkboxes ensures comprehensive coverage.`
+
+// ============================================
+// 8-STEP DEVELOPMENT LIFECYCLE
+// ============================================
+
+export interface LifecycleStep {
+  step: number
+  name: string
+  tool: string
+  output: string
+  description: string
+}
+
+export const developmentLifecycle: LifecycleStep[] = [
+  { step: 1, name: "Generate Prompts", tool: "Claude Code CLI", output: "RESEARCH_PROMPT.md, BUILD_PROMPT.md", description: "Master meta-prompt generates all sub-prompts needed for the project" },
+  { step: 2, name: "Research", tool: "Claude.ai (Web)", output: "Session outputs (multi-session)", description: "Competitive intelligence via web search. Continuation-first approach ensures context preservation." },
+  { step: 3, name: "Compile Research", tool: "Claude.ai or CLI", output: "COMPILED_RESEARCH.md", description: "Combine all sessions into single document with gap analysis and deduplication" },
+  { step: 4, name: "Build Project", tool: "Claude Code CLI", output: "Project scaffold, ROADMAP.md, SDDs", description: "Two-phase initialization: verify understanding, then scaffold. Creates AGENT_PROMPT.md." },
+  { step: 5, name: "Iterative Development", tool: "Claude Code CLI", output: "Feature branches, PRs", description: "Mass feature builds with branch chaining. Each feature on its own branch/PR." },
+  { step: 6, name: "3-Pass Code Review", tool: "Claude Code CLI", output: "Review comments, fix PRs", description: "Pass 1: Critical bugs/security. Pass 2: Edge cases/async. Pass 3: Integration/regression." },
+  { step: 7, name: "Quality Gate", tool: "Claude Code CLI", output: "Verification report", description: "No placeholders, portfolio-presentable, 80%+ coverage, all pipelines pass, docs complete." },
+  { step: 8, name: "Merge & Deploy", tool: "Claude Code CLI", output: "Production deployment", description: "Merge PRs, deploy to Render/Vercel/AWS. Demo mode enabled for portfolio showcase." },
+]
+
+// ============================================
+// MULTI-AGENT ORCHESTRATION
+// ============================================
+
+export const multiAgentSystem = `4 concurrent AI agent work slots (A, B, C, D) with atomic directory-based locking.
+Agents claim slots before starting work. Conflict detection prevents overwrites.
+Append-only commit logs create an audit trail. Setup automated to ~5 seconds via shell scripts.
+
+Architecture:
+- epic-setup.sh: Creates folder structure, templates, tracking files in seconds
+- bug-setup.sh: Automated bug handling with coordination templates
+- smart-dispatcher.sh: Routes tasks to available agent slots
+- agent-helpers.sh: Shared utilities for all agents
+- Heartbeat monitoring: Detects stalled agents and reclaims slots`
+
+export const multiAgentWorkSlots = [
+  { slot: "A", status: "Primary", description: "Main development work, feature implementation" },
+  { slot: "B", status: "Secondary", description: "Parallel feature work, independent tasks" },
+  { slot: "C", status: "Support", description: "Documentation, testing, review tasks" },
+  { slot: "D", status: "Reserve", description: "Bug fixes, hotfixes, overflow tasks" },
+]
+
+// ============================================
+// MARKET RESEARCH & VALIDATION
+// ============================================
+
+export interface MarketResearch {
+  project: string
+  market: string
+  keyInsight: string
+  pricing: string
+  differentiator: string
+}
+
+export const marketResearchReports: MarketResearch[] = [
+  { project: "RapidBooth", market: "SMB Website Builder", keyInsight: "No competitor combines field sales + AI intake + 30-minute delivery", pricing: "$30/month (40-67% gross margin)", differentiator: "In-person sales + conversational AI + instant delivery" },
+  { project: "Patent Intelligence", market: "$1-2B Patent Analytics", keyInsight: "EPO released free patent data; incumbents charge $20K-100K+/yr", pricing: "$49-299/month tiered", differentiator: "Semantic search across 200M+ patents at 1/100th the cost" },
+  { project: "Baked by Chrissy", market: "$3.2B Home Baker Gap", keyInsight: "Bakers use 4-6 disconnected programs per order; 39.5% unsure if profitable", pricing: "$15-25/month", differentiator: "Image upload in ordering flow (no competitor offers this)" },
+  { project: "ChoreChamp", market: "$542M Parenting Apps", keyInsight: "7-day streak = 3.6x retention; kids lose interest in 2-4 weeks with competitors", pricing: "$9.99/month or $59.99/year", differentiator: "First neurodivergent-friendly family chore app" },
+  { project: "GenomeForge", market: "Genetic Analysis (23andMe bankruptcy)", keyInsight: "23andMe bankruptcy + 6.9M data breach creating privacy anxiety", pricing: "$29-49 one-time", differentiator: "DNA never leaves user's device (architecturally impossible for competitors)" },
+  { project: "ReadForge", market: "$2B+ TTS Market", keyInsight: "Speechify charges $139/yr with 150K word limit; reverts to robotic voices", pricing: "Freemium", differentiator: "Kokoro-82M ranked #1 on TTS Arena, runs 100% locally" },
+  { project: "WriteForge", market: "$3B+ Writing Assistant", keyInsight: "Privacy is #1 complaint about Grammarly (described as 'essentially a keylogger')", pricing: "Freemium", differentiator: "100% local processing, BYOK AI, system-wide access" },
+  { project: "TreasureTrail", market: "$2-4B Estate/Yard Sales", keyInsight: "EstateSales.NET acquired for $40M (2023); 60-70% of buyers are resellers", pricing: "$49/month B2B", differentiator: "VROOM route optimization (no competitors have this)" },
+  { project: "Rave Collective", market: "$2.3B Festival Fashion (8.4% CAGR)", keyInsight: "Etsy exodus: active sellers dropped 27%, fees at 20-25%", pricing: "10% platform fee (50-60% lower than Etsy)", differentiator: "UV/blacklight preview (industry-first in any e-commerce)" },
+  { project: "Learning Hall", market: "$28.6B LMS (20% CAGR)", keyInsight: "Teachable stores in 'unique format that can't be opened by any other software'", pricing: "Competitive with Teachable ($29-139/mo)", differentiator: "BYOS (Bring Your Own Storage) is a genuine market gap" },
+  { project: "Research Agent", market: "AI Research Tools", keyInsight: "83.9% of context tokens in agent loops come from tool observations", pricing: "$0.06-0.15/session (96-97% cost reduction vs naive)", differentiator: "Crash-resilient, locally-run deep research with checkpoint resumption" },
+]
+
+// ============================================
+// CAREER CONTEXT
+// ============================================
+
+export interface CareerEntry {
+  period: string
+  role: string
+  company: string
+  highlights: string[]
+}
+
+export const careerTimeline: CareerEntry[] = [
+  { period: "Early", role: "Entrepreneur", company: "Various Ventures", highlights: ["Lawn care, snow removal, door-to-door sales", "Real estate: bought first properties before having a driver's license", "Phones For Fast Cash: 500+ device repairs over 4 years", "Flying Colors Paintball: business acquisition and operations"] },
+  { period: "2019", role: "Teaching Assistant", company: "Lake Land College", highlights: ["Tutored HTML, CSS, JavaScript, Python", "Comfort Order vision born (Thanksgiving 2019)"] },
+  { period: "2020", role: "App Academy Graduate", company: "App Academy", highlights: ["<3% acceptance rate, 60-80 hour weeks", "Full-stack web development intensive"] },
+  { period: "2020-2022", role: "Full-Stack Engineer", company: "Charter Communications", highlights: ["Built POC generating production-grade code from user interactions", "Enterprise-scale development experience"] },
+  { period: "2021-2024", role: "Co-Founder & Principal Engineer", company: "Tailored Technologies", highlights: ["Golf industry client work (PGA, SMC)", "36 production prompts (836KB) forged under real production pressure", "15 Strapi plugins, 7+ independent contractor agreements", "19 weekly PGA status reports, 421 meeting recordings"] },
+  { period: "2022-2023", role: "Enterprise Engineer", company: "First American", highlights: ["Enterprise microservices, AWS serverless"] },
+  { period: "2023", role: "Senior Developer", company: "Mesirow Financial", highlights: ["Wealth management modernization", "30% performance improvement"] },
+  { period: "2024-2026", role: "Senior Software Engineer", company: "BrainGu", highlights: ["DoD applications for Space Force, Air Force, Navy", "5 DoD applications with secure AI integration"] },
+]
+
+// ============================================
+// SDD-FIRST DEVELOPMENT
+// ============================================
+
+export const sddFirstDescription = `Software Design Documents (SDDs) are created BEFORE writing any code. This is enforced through automatic triggers.`
+
+export const sddTriggers = [
+  "New features with 3+ components or files",
+  "Complex functionality requiring database changes",
+  "API integrations or new endpoints",
+  "Multi-step workflows or business processes",
+  "Reusable systems or shared libraries",
+  "User interfaces with multiple views or states",
+]
+
+export const sddNoPLaceholders = `"TBD", "See implementation for details", empty sections, "Details to follow", and incomplete tables are NEVER acceptable in SDDs. Every section must be filled with actionable, specific content before implementation begins.`
+
+// ============================================
+// QUALITY CHECKLISTS
+// ============================================
+
+export const qualityChecklists = [
+  { name: "PRE_COMMIT", purpose: "Run before every commit. Checks file size (<300 lines), forbidden patterns, type safety." },
+  { name: "PRE_MR", purpose: "Run before creating a merge/pull request. Validates documentation, test coverage, code standards." },
+  { name: "CODE_REVIEW", purpose: "3-pass review checklist. Critical bugs, edge cases, then integration verification." },
+  { name: "DOCUMENTATION", purpose: "Ensures README, ARCHITECTURE, ROADMAP, and SDDs are all current." },
+  { name: "AI_WORK_VALIDATION", purpose: "Validates AI-generated code meets all human-authored standards." },
+  { name: "MIGRATION", purpose: "Checklist for database migrations, API changes, and breaking changes." },
+]
+
+// ============================================
+// DOCUMENT HIERARCHY
+// ============================================
+
+export const documentHierarchy = [
+  { level: 1, name: "~/.claude/CLAUDE.md", description: "Global rules: git workflow, forbidden patterns, testing requirements, service naming, demo mode" },
+  { level: 2, name: "AI_DEV_DOCS_MASTER/", description: "Consolidated reference library. 159 source files compressed to 23 outputs (92% compression ratio)" },
+  { level: 3, name: "_@agent-prompts/", description: "Meta-prompt system: PROJECT_GENERATOR, PROMPTS_REFERENCE, WORKFLOW_GUIDE, START_HERE_TEMPLATE, 8 knowledge base docs" },
+  { level: 4, name: "Project-Workflow-Prompts/", description: "Individual step files (Step 1 through Step 8 of the development lifecycle)" },
+  { level: 5, name: "Per-project .claude/", description: "Project-specific rules (enterprise-template-system has 8 specialized files)" },
+  { level: 6, name: "Per-project CLAUDE.md", description: "Project-level overrides (Jarvis, dev-environment-setup)" },
+  { level: 7, name: "Per-project docs/", description: "ARCHITECTURE.md, ROADMAP.md, sdd/ directories found across 35+ projects" },
+]
+
+// ============================================
+// GOOGLE DRIVE ARCHIVE
+// ============================================
+
+export const googleDriveStats = {
+  totalItems: "702,165",
+  totalSize: "626.71 GB",
+  emailsExported: "63,316 RFC822 files (~4.68 GB) from 10+ accounts",
+  meetingRecordings: "421 recordings (91.01 GB)",
+  transcriptions: "46 VTT transcription files",
+  backupArchives: "ran.zip (156.81 GB), Personal projects.zip (22.19 GB)",
+  allAiWork: "40,408 items, 836 MB of AI development artifacts",
+}
 
 // ============================================
 // LESSONS LEARNED

--- a/src/data/ai-development.ts
+++ b/src/data/ai-development.ts
@@ -1106,6 +1106,295 @@ export const additionalFindings = {
 }
 
 // ============================================
+// TESTING INFRASTRUCTURE
+// ============================================
+
+export interface TestingStats {
+  metric: string
+  value: string
+}
+
+export const testingInfraStats: TestingStats[] = [
+  { metric: "Total test files", value: "2,918" },
+  { metric: "Total test lines of code", value: "559,535" },
+  { metric: "Average lines per test file", value: "192" },
+  { metric: "Projects with test suites", value: "30+" },
+  { metric: "Unit test files (.test)", value: "2,465" },
+  { metric: "E2E test files (.spec)", value: "383" },
+  { metric: "Integration test suites", value: "10+" },
+]
+
+export interface TestDistribution {
+  language: string
+  files: string
+  percentage: string
+}
+
+export const testDistribution: TestDistribution[] = [
+  { language: "TypeScript React (.tsx)", files: "1,737", percentage: "59.5%" },
+  { language: "TypeScript (.ts)", files: "569", percentage: "19.5%" },
+  { language: "Python (.py)", files: "398", percentage: "13.6%" },
+  { language: "JavaScript (.js)", files: "174", percentage: "6.0%" },
+  { language: "JavaScript React (.jsx)", files: "40", percentage: "1.4%" },
+]
+
+export interface TopTestedProject {
+  project: string
+  testFiles: string
+  lines: string
+  framework: string
+}
+
+export const topTestedProjects: TopTestedProject[] = [
+  { project: "enterprise-template-system", testFiles: "492", lines: "142,627", framework: "Playwright + Vitest" },
+  { project: "enterprise-component-library", testFiles: "1,280", lines: "104,505", framework: "Jest + Vitest" },
+  { project: "SpecTree", testFiles: "333", lines: "92,354", framework: "Vitest + Jest" },
+  { project: "rave-collective", testFiles: "119", lines: "57,862", framework: "Vitest" },
+  { project: "Comfort-Order", testFiles: "204", lines: "48,982", framework: "Playwright + Vitest" },
+  { project: "coc-game", testFiles: "25", lines: "18,148", framework: "Vitest (game AI)" },
+  { project: "Ordering-and-tracking-application", testFiles: "99", lines: "16,325", framework: "Vitest + Jest" },
+  { project: "bread-of-heaven", testFiles: "38", lines: "4,061", framework: "Vitest" },
+]
+
+export interface TestFramework {
+  name: string
+  projects: string
+  purpose: string
+}
+
+export const testFrameworks: TestFramework[] = [
+  { name: "Vitest", projects: "15+ (primary)", purpose: "Modern TypeScript testing with coverage" },
+  { name: "Jest", projects: "6 (legacy)", purpose: "Node.js and older projects" },
+  { name: "Playwright", projects: "2", purpose: "Multi-browser E2E testing" },
+  { name: "Pytest", projects: "6+", purpose: "Python project testing" },
+  { name: "Codecov", projects: "12", purpose: "Coverage reporting and tracking" },
+  { name: "SonarCloud", projects: "6", purpose: "Code quality analysis" },
+]
+
+export const testingBlindSpot = `18 projects integrate AI/LLM packages, but zero have dedicated AI output validation tests. No tests exist for prompt injection, model output validation, embedding accuracy, token budget enforcement, or LLM response schema compliance. The AI integration layer is the least-tested part of the stack.`
+
+// ============================================
+// CI/CD WORKFLOW PATTERNS
+// ============================================
+
+export interface CICDStats {
+  metric: string
+  value: string
+}
+
+export const cicdStats: CICDStats[] = [
+  { metric: "Total workflow files", value: "45" },
+  { metric: "Total workflow lines", value: "6,122" },
+  { metric: "Average workflow size", value: "136 lines" },
+  { metric: "Repos with GitHub Actions", value: "46" },
+  { metric: "CodeRabbit configs (91%)", value: "42" },
+  { metric: "Dependabot configs (89%)", value: "41" },
+  { metric: "Codecov configs (28%)", value: "13" },
+]
+
+export interface CICDTier {
+  tier: string
+  repos: string
+  percentage: string
+  description: string
+}
+
+export const cicdTiers: CICDTier[] = [
+  { tier: "Tier 1 - Basic", repos: "35", percentage: "76%", description: "Checkout, Install, Lint, Type check, Test, Build. Average 40-60 lines." },
+  { tier: "Tier 2 - Intermediate", repos: "10", percentage: "22%", description: "Tier 1 + Codecov upload + Render deployment. Matrix strategies for Node versions. Average 80-120 lines." },
+  { tier: "Tier 3 - Sophisticated", repos: "1", percentage: "2%", description: "enterprise-template-system: 12 workflows (6,122 lines), Turbo monorepo, AWS ECR/ECS/Terraform, k6 load testing, Lighthouse audits, multi-browser E2E, Slack notifications, auto-rollback." },
+]
+
+export const cicdZeroAISteps = `Despite 18 projects integrating AI/LLM packages, there are zero prompt validation steps, zero model output testing, zero token budget enforcement, zero AI attribution scanning (em dash detection, "Co-Authored-By" detection), and zero automated checks for forbidden AI patterns in any CI pipeline. All AI quality enforcement is done through agent instructions (CLAUDE.md), not CI automation.`
+
+// ============================================
+// DEPENDENCY ECOSYSTEM
+// ============================================
+
+export interface DependencyCategory {
+  category: string
+  count: string
+}
+
+export const dependencyScale: DependencyCategory[] = [
+  { category: "Node.js package.json files", count: "74" },
+  { category: "Python dependency files", count: "18" },
+  { category: "Swift Package.swift files", count: "1+" },
+  { category: "Projects with AI/LLM packages", count: "18 (33%)" },
+]
+
+export interface AIPackage {
+  name: string
+  projectsUsing: string
+  version: string
+}
+
+export const aiPackages: AIPackage[] = [
+  { name: "@anthropic-ai/sdk", projectsUsing: "4", version: "v0.30.0 - v0.71.2" },
+  { name: "openai", projectsUsing: "4", version: "v4.24.1 - v6.16.0" },
+  { name: "@google/generative-ai", projectsUsing: "3", version: "v0.1.3 - v0.24.1" },
+  { name: "litellm", projectsUsing: "1 (Research Agent)", version: ">= 1.50" },
+  { name: "langgraph", projectsUsing: "1 (Research Agent)", version: ">= 1.0" },
+  { name: "chromadb", projectsUsing: "1 (Research Agent)", version: ">= 1.4" },
+  { name: "@mlc-ai/web-llm", projectsUsing: "1 (WriteForge)", version: ">= 0.2.0" },
+  { name: "sentence-transformers", projectsUsing: "1 (Patent Intelligence)", version: ">= 2.3.0" },
+  { name: "pgvector", projectsUsing: "1 (Patent Intelligence)", version: ">= 0.2.4" },
+  { name: "openai-whisper", projectsUsing: "1 (Jarvis)", version: "N/A" },
+  { name: "ollama", projectsUsing: "2 (Jarvis, Chronoscribe)", version: "Local runtime" },
+  { name: "tiktoken", projectsUsing: "1 (Research Agent)", version: ">= 0.8" },
+  { name: "tavily-python", projectsUsing: "1 (Research Agent)", version: ">= 0.5" },
+]
+
+export interface UILibraryUsage {
+  library: string
+  projects: string
+}
+
+export const uiLibraryUsage: UILibraryUsage[] = [
+  { library: "Radix UI", projects: "35+" },
+  { library: "React Hook Form", projects: "30+" },
+  { library: "TailwindCSS", projects: "40+" },
+  { library: "Zod", projects: "30+" },
+  { library: "Framer Motion", projects: "15+" },
+  { library: "React Query", projects: "15+" },
+]
+
+export const proprietaryPackages = [
+  { name: "@writeforge/core-llm", project: "WriteForge", purpose: "Browser-based LLM abstraction via WebLLM" },
+  { name: "@lcc/llm", project: "LifeContextCompiler", purpose: "LLM integration for context compilation" },
+  { name: "@repo/typescript-config", project: "Shared config", purpose: "Cross-project TypeScript configuration" },
+]
+
+export const deepestAIStack = `Research Agent has the deepest AI dependency graph: litellm (100+ LLM providers), langgraph (agent orchestration), chromadb (vector RAG), tiktoken (cost estimation), tavily-python (web search), trafilatura + crawl4ai (scraping), sentence-transformers (local embeddings), torch (local inference).`
+
+// ============================================
+// INFRASTRUCTURE & DEPLOYMENT
+// ============================================
+
+export interface InfraResource {
+  resource: string
+  count: string
+}
+
+export const infraScale: InfraResource[] = [
+  { resource: "Dockerfiles", count: "78" },
+  { resource: "docker-compose files", count: "65" },
+  { resource: "render.yaml configs", count: "49" },
+  { resource: "Prisma schema files", count: "8" },
+  { resource: "Database migration files", count: "33" },
+  { resource: "Zod schema files", count: "13" },
+  { resource: "API route files", count: "984" },
+]
+
+export interface DatabaseUsage {
+  database: string
+  projects: string
+  useCase: string
+}
+
+export const databaseUsage: DatabaseUsage[] = [
+  { database: "PostgreSQL", projects: "10+", useCase: "Primary relational DB" },
+  { database: "pgvector", projects: "2", useCase: "Vector embeddings (Patent Intelligence, Research Agent)" },
+  { database: "Redis", projects: "8+", useCase: "Caching, job queues (BullMQ)" },
+  { database: "MongoDB", projects: "8+", useCase: "Document storage" },
+  { database: "SQLite", projects: "3+", useCase: "Local/embedded (GenomeForge, archive DB)" },
+  { database: "ChromaDB", projects: "1", useCase: "Vector DB for RAG (Research Agent)" },
+]
+
+export interface APIFramework {
+  framework: string
+  projects: string
+  useCase: string
+}
+
+export const apiFrameworks: APIFramework[] = [
+  { framework: "Express.js", projects: "25+", useCase: "Primary Node.js backend" },
+  { framework: "FastAPI", projects: "8", useCase: "Python APIs (Research Agent, Patent Intelligence)" },
+  { framework: "Next.js API routes", projects: "20+", useCase: "Full-stack React apps" },
+  { framework: "Hono", projects: "2", useCase: "Lightweight edge APIs" },
+  { framework: "Strapi 5", projects: "5+", useCase: "Headless CMS (enterprise-template, CodeReview AI)" },
+]
+
+// ============================================
+// SDD COVERAGE DETAILS
+// ============================================
+
+export interface SDDProject {
+  project: string
+  sddFiles: string
+  phases: string
+}
+
+export const sddCoverageDetails: SDDProject[] = [
+  { project: "enterprise-template-system", sddFiles: "16", phases: "CMS, theme, nav, footer, RBAC, media, testing, config" },
+  { project: "treasuretrail", sddFiles: "16", phases: "4 phases (auth, maps, routes, sync, B2B, analytics)" },
+  { project: "patent-intelligence", sddFiles: "9", phases: "10 phases (search, EPO, similarity, citations, white space)" },
+  { project: "chronoscribe", sddFiles: "10", phases: "3 phases (watch, OCR, analysis, timeline, categorization)" },
+  { project: "baked-by-chrissy", sddFiles: "8", phases: "10 phases (portfolio, menu, orders, payments, admin)" },
+  { project: "save-a-stray", sddFiles: "8", phases: "2 phases (auth, GraphQL, real-time, search, analytics)" },
+  { project: "SpecTree", sddFiles: "5+", phases: "4 phases (drag-drop, AI backend, exports)" },
+  { project: "research-agent", sddFiles: "5", phases: "1 phase (orchestration, search, checkpoint, synthesis)" },
+  { project: "writeforge", sddFiles: "5", phases: "4 phases (LanguageTool, extension, desktop, LLM)" },
+]
+
+export const sddStats = {
+  totalFiles: "77",
+  architectureMdFiles: "37",
+  roadmapMdFiles: "47",
+  projectsWithSddDirs: "24",
+  sddTemplatesFound: "6",
+  namingConventions: "Sequential (SDD-001) and Feature-based (F1.1)",
+}
+
+// ============================================
+// PROMPT INFRASTRUCTURE SCALE
+// ============================================
+
+export interface PromptInfraMetric {
+  resource: string
+  count: string
+  totalSize: string
+}
+
+export const promptInfraScale: PromptInfraMetric[] = [
+  { resource: "Total markdown files in _@agent-prompts", count: "317", totalSize: "7.86 MB" },
+  { resource: "START_HERE.md files", count: "58", totalSize: "51,598 lines (avg 1,761/file)" },
+  { resource: "AGENT_PROMPT.md files", count: "25", totalSize: "11,841 lines (avg 905/file)" },
+  { resource: "BUILD_PROMPT.md files", count: "23", totalSize: "14,750 lines (avg 1,247/file)" },
+  { resource: "COMPILED_RESEARCH.md files", count: "11", totalSize: "35,310 lines (avg 3,210/file)" },
+  { resource: "WORK_LOG.md files", count: "25", totalSize: "1,717 lines (avg 69/file)" },
+  { resource: "Research session files", count: "75", totalSize: "In research/sessions/ directories" },
+  { resource: "Projects with prompt infrastructure", count: "62", totalSize: "Under _@agent-prompts" },
+]
+
+export const largestCompiledResearch = [
+  { project: "ChoreChamp", lines: "~3,800", size: "148 KB" },
+  { project: "TreasureTrail", lines: "~3,000", size: "118 KB" },
+  { project: "Rave Collective", lines: "~2,700", size: "106 KB" },
+]
+
+// ============================================
+// TEMPLATE-DRIVEN CONSISTENCY
+// ============================================
+
+export const templateConsistencyDescription = `The PROJECT_GENERATOR_PROMPT doesn't just generate code structure. It also produces consistent infrastructure: 45 near-identical CI workflows, 42 identical CodeRabbit configs, 41 identical Dependabot configs, 13 identical Codecov configs, 24 SDD directory structures, and 58 START_HERE.md onboarding docs. This is "infrastructure as prompt output."`
+
+export interface MaturityTier {
+  tier: string
+  percentage: string
+  description: string
+}
+
+export const portfolioMaturitySpectrum: MaturityTier[] = [
+  { tier: "Nascent", percentage: "20%", description: "Basic CI, no tests, minimal docs" },
+  { tier: "Standard", percentage: "60%", description: "Template-based CI + CodeRabbit + Dependabot + Codecov" },
+  { tier: "Advanced", percentage: "18%", description: "Full test suites + SDDs + compiled research + comprehensive docs" },
+  { tier: "Enterprise", percentage: "2%", description: "Full AWS infra + security scanning + performance testing + multi-env deploys" },
+]
+
+export const enterpriseOutlier = `enterprise-template-system accounts for: 12 CI workflows, 142,627 lines of test code, 16 SDDs, Terraform infrastructure, AWS ECR/ECS, k6 load testing, Lighthouse audits, multi-browser E2E, and the only comprehensive security scanning in the portfolio. It represents the "target state" that other projects aspire to reach.`
+
+// ============================================
 // LESSONS LEARNED
 // ============================================
 

--- a/src/data/ai-development.ts
+++ b/src/data/ai-development.ts
@@ -1,0 +1,753 @@
+// ============================================
+// AI Development - Complete Content Data
+// ============================================
+
+export interface AIStat {
+  label: string
+  value: string
+  description: string
+}
+
+export interface TimelineEntry {
+  year: string
+  title: string
+  description: string
+  milestone?: boolean
+}
+
+export interface PromptPattern {
+  id: string
+  number: number
+  name: string
+  source: string
+  problem: string
+  solution: string
+  keyInsight: string
+  template?: string
+}
+
+export interface AIProject {
+  id: string
+  name: string
+  status: string
+  purpose: string
+  innovation: string
+  aiFeatures: string[]
+  stack: string[]
+}
+
+export interface LLMProvider {
+  tier: string
+  provider: string
+  models: string
+  useCase: string
+}
+
+export interface VoiceProject {
+  project: string
+  technology: string
+  latency: string
+  keyFeature: string
+}
+
+export interface PrivacyProject {
+  project: string
+  approach: string
+}
+
+export interface QualityMetric {
+  metric: string
+  minimum: string
+}
+
+export interface AITool {
+  name: string
+  stats: string
+  purpose: string
+}
+
+export interface UseCase {
+  id: string
+  title: string
+  description: string
+  codeSnippet?: string
+}
+
+export interface Lesson {
+  number: number
+  title: string
+  insight: string
+}
+
+export interface EnterprisePattern {
+  title: string
+  description: string
+  details: string[]
+}
+
+// ============================================
+// KEY STATS (for homepage section + page hero)
+// ============================================
+
+export const aiStats: AIStat[] = [
+  { label: "Projects with AI Prompts", value: "77+", description: "Each with structured agent prompt infrastructure" },
+  { label: "Production AI Products", value: "11", description: "Shipped, working AI-powered applications" },
+  { label: "Reusable Prompt Patterns", value: "10", description: "Battle-tested across dozens of projects" },
+  { label: "Claude Code Sessions", value: "273", description: "Consolidated, recoverable development sessions" },
+  { label: "Enterprise Prompts", value: "36", description: "Production prompts from client work (836KB)" },
+  { label: "Test Coverage", value: "97.7%", description: "Research Agent branch coverage" },
+]
+
+// ============================================
+// JOURNEY TIMELINE
+// ============================================
+
+export const journeyTimeline: TimelineEntry[] = [
+  {
+    year: "2019",
+    title: "Comfort Order - The Vision",
+    description: "Thanksgiving 2019. The core insight: large businesses spend $1-10M on software for competitive advantage. Small businesses have passion and quality but lack automation. The solution: build reusable, customizable components that democratize technology for small businesses.",
+    milestone: true,
+  },
+  {
+    year: "2020-2021",
+    title: "CAD Consulting - First Pivot",
+    description: "Pivoted to consulting services, building custom software for local businesses. Learned firsthand what small business owners actually need versus what technologists assume they need.",
+  },
+  {
+    year: "2021-2023",
+    title: "Tailored Technologies - Enterprise Client Work",
+    description: "Golf industry focus with a 50/50 partnership. Built booking systems, membership management, payment processing (Stripe + QuickBooks), coach scheduling, 15 Strapi plugins, and 36 production prompts (836KB). This is where the AI-augmented development patterns were forged under real production pressure.",
+    milestone: true,
+  },
+  {
+    year: "Oct 2024",
+    title: "Pattern Extraction Begins",
+    description: "Partnership dissolved. Instead of losing the work, systematically extracted every pattern, template, and workflow into reusable open-source systems. Enterprise Template System, Component Library, and the Agent Prompt System were born from production battle scars.",
+    milestone: true,
+  },
+  {
+    year: "2024-2025",
+    title: "The Ecosystem Takes Shape",
+    description: "Built the _@agent-prompts system, the Project Generator meta-prompt (95KB), 4 meta-prompts that generate other prompts, cross-machine agent sync, and standardized the 5-phase workflow across all projects. Started shipping AI-powered products: Patent Intelligence, CodeReview AI, SpecTree.",
+    milestone: true,
+  },
+  {
+    year: "2025-2026",
+    title: "77+ Projects, Full Production Pipeline",
+    description: "The ecosystem hit full stride. 77+ projects managed through structured AI agent workflows. Voice-first AI with full duplex conversation at <500ms latency. Privacy-first architecture across all projects. 273 Claude Code sessions tracked and recoverable. Research Agent shipped with 97.7% test coverage.",
+    milestone: true,
+  },
+]
+
+// ============================================
+// THE ECOSYSTEM - "Apps That Build Apps"
+// ============================================
+
+export const ecosystemDescription = `The entire system is designed as a recursive, self-improving pipeline for building applications at any scale using AI agents, production-tested templates, and human-in-the-loop orchestration. It transforms the software development lifecycle from a manual, time-intensive process into an AI-augmented pipeline where ideas become specifications, specifications become prompts, prompts guide AI agents through research and development, templates accelerate scaffolding, and quality gates ensure production readiness.`
+
+export const ecosystemLayers = [
+  { layer: "Layer 0", name: "Context Capture", tool: "LifeContextCompiler", flow: "Ideas from life into structured context" },
+  { layer: "Layer 1", name: "Specification", tool: "SpecTree / Blueprint Builder", flow: "Context into actionable specifications" },
+  { layer: "Layer 2", name: "Orchestration", tool: "_@agent-prompts", flow: "Specifications into AI agent workflows" },
+  { layer: "Layer 3", name: "Foundation", tool: "Enterprise Templates + Component Library", flow: "Scaffolding into accelerated project setup" },
+  { layer: "Layer 4+", name: "Production Applications", tool: "Working Software", flow: "Deployed to real users" },
+]
+
+export const qualityTriangle = `You can only pick TWO: Price, Speed/Convenience, Quality. Large businesses optimize for price and speed at the expense of quality. This ecosystem enables small businesses to compete by automating what previously required expensive custom software.`
+
+export const nonprofitStrategy = `For every for-profit location signed up, fund a nonprofit location's software for free. Sign up 1 pizzeria, fund 1 dog shelter. Sign up 3 pizzerias, fund a local food bank. This creates ethical differentiation, valuable feedback loops, and a competitive advantage that extractive companies cannot match.`
+
+// ============================================
+// AGENT PROMPT SYSTEM
+// ============================================
+
+export const agentPromptSystemDescription = `A centralized, version-controlled repository of AI agent prompts stored SEPARATELY from project code. This prevents agents from modifying their own instructions while providing structured, reproducible workflows for every project.`
+
+export const agentPromptWorkflow = `RESEARCH PHASE              COMPILE PHASE          BUILD PHASE         DEVELOP PHASE
+
+Session 1 ──────┐
+Session 2 ──────┼──> COMPILER_PROMPT ──> COMPILED_RESEARCH ──> BUILD_PROMPT ──> AGENT_PROMPT
+Session N ──────┘                           + Gap Analysis
+
+AI Agent: Claude.ai          Claude.ai or CLI   Claude Code (CLI)   Claude Code (CLI)
+Can Do:   Web search          Gap analysis       File creation       Code implementation`
+
+export const metaPrompts = [
+  { name: "PROJECT_GENERATOR_PROMPT", size: "95 KB, 3,227 lines", description: "Master meta-prompt that creates all sub-prompts for new projects. Input: project idea. Output: RESEARCH_PROMPT, BUILD_PROMPT, AGENT_PROMPT template." },
+  { name: "ENHANCEMENT_RESEARCH_GENERATOR", size: "For active projects", description: "For existing projects in active development (3-6 months post-launch). Generates enhancement research prompts focused on feature gaps." },
+  { name: "RESEARCH_COMPILER_PROMPT", size: "Multi-session", description: "Combines multiple research sessions into a single compiled document with gap analysis for topics needing more research." },
+  { name: "NONPROFIT_GENERATOR_PROMPT", size: "33 KB", description: "Specialized variant for nonprofit-serving projects. Includes ecosystem research and nonprofit-specific constraints." },
+]
+
+export const projectStructure = `project-name/
+├── README.md              # Status tracker with checklist
+├── WORK_LOG.md            # Session tracking with handoff notes
+├── AGENT_PROMPT.md        # Development template (ongoing work)
+├── BUILD_PROMPT.md        # Build phase instructions
+├── START_HERE.md          # Onboarding for new agents
+└── research/
+    ├── RESEARCH_PROMPT.md           # Initial competitor research
+    ├── sessions/                     # Research session outputs
+    │   ├── session-1.md
+    │   ├── session-2.md
+    │   └── session-N.md
+    └── COMPILED_RESEARCH.md          # Final combined document`
+
+// ============================================
+// 10 BATTLE-TESTED PROMPT PATTERNS
+// ============================================
+
+export const promptPatterns: PromptPattern[] = [
+  {
+    id: "project-generator",
+    number: 1,
+    name: "Project Generator Meta-Prompt",
+    source: "triple-a-lemonade (PROJECT_GENERATOR_PROMPT v2.0.0)",
+    problem: "Starting new projects from scratch is slow and inconsistent. Different projects get different quality levels of planning.",
+    solution: "A master prompt that generates all sub-prompts needed for a new project: RESEARCH_PROMPT, BUILD_PROMPT, and AGENT_PROMPT template.",
+    keyInsight: "Store prompts in a SEPARATE private repo to prevent agents from modifying their own instructions.",
+  },
+  {
+    id: "two-phase-init",
+    number: 2,
+    name: "Two-Phase Initialization",
+    source: "save-a-stray and triple-a-lemonade sessions",
+    problem: "Agents dive straight into building without verifying they understand the requirements, often building the wrong thing entirely.",
+    solution: "Force the agent to verify understanding before doing any work. The agent must describe the product, list components, identify differentiators, and ask questions. Then WAIT for confirmation before proceeding.",
+    keyInsight: "Research is injected separately (not all at once) to prevent context overload. The AGENT_PROMPT becomes the single source of truth for future sessions.",
+  },
+  {
+    id: "iterative-multi-phase",
+    number: 3,
+    name: "Iterative Multi-Phase Development",
+    source: "save-a-stray session (Prompt 11)",
+    problem: "Manually managing CI pipelines and branching between development phases is tedious and error-prone.",
+    solution: "Tell the agent to work through multiple development phases autonomously: monitor pipelines, fix failures, create new branches, implement features, push, create PRs, repeat.",
+    keyInsight: "One prompt can drive hours of autonomous development across multiple phases. The agent self-corrects on CI failures without human intervention.",
+    template: `Monitor the pipelines and if anything is broken, fix it. Then check out to a new branch from the one you're on and work on the next phase. Keep doing that for the next N phases.`,
+  },
+  {
+    id: "mass-feature-build",
+    number: 4,
+    name: "Mass Feature Build (N Features, N PRs)",
+    source: "gmail-organizer session (Prompt 22/31)",
+    problem: "Building many features manually is slow. Each needs its own branch, PR, tests, documentation, and website updates.",
+    solution: "Instruct the agent to build all N features autonomously, each on its own branch/PR, with full quality standards: no placeholders, no bugs, all pipelines passing, docs updated, website updated.",
+    keyInsight: "Setting explicit quality gates in the prompt (portfolio-ready, zero bugs, all pipelines pass) produces dramatically better results than vague instructions.",
+    template: `Build out all N features. Each in its own PR on its own branch. Full functionality, no placeholder code. Presentable for a portfolio project with no bugs or security issues. All pipelines must pass. Documentation, roadmaps, READMEs, architecture diagrams, and website all updated per MR.`,
+  },
+  {
+    id: "three-pass-review",
+    number: 5,
+    name: "3-Pass Code Review via PR Comments",
+    source: "gmail-organizer session (Prompt 34)",
+    problem: "Single-pass code reviews miss issues. Reviewers develop blind spots to code they just wrote.",
+    solution: "Three independent review passes: Pass 1 catches critical bugs (security, logic, crashes). Pass 2 finds secondary issues (async, edge cases). Pass 3 verifies integration (automated tests, cross-module, regression).",
+    keyInsight: "Telling the agent to review 'as if you didn't write it' produces genuinely different perspectives on each pass. Fresh eyes, even simulated ones, catch real bugs.",
+    template: `Do a thorough code review as if you didn't write it. Go MR by MR, posting comments, then fixing them. Audit at least three times independently. Take your time.`,
+  },
+  {
+    id: "docs-per-mr",
+    number: 6,
+    name: "Documentation-Per-MR Requirements",
+    source: "gmail-organizer session",
+    problem: "Documentation falls behind code. By the time features ship, nobody remembers what to document.",
+    solution: "Every PR must update: README.md, ARCHITECTURE.md, ROADMAP.md, Software Design Documents, website/landing page, and code comments for non-obvious logic.",
+    keyInsight: "Making documentation a PR requirement (not a separate task) ensures it stays current. Agents are surprisingly good at writing technical documentation when explicitly asked.",
+  },
+  {
+    id: "continuation-first",
+    number: 7,
+    name: "Continuation-First Research",
+    source: "triple-a-lemonade Project Generator (Part 2)",
+    problem: "When agents generate continuation prompts AFTER researching, they forget context or produce incomplete handoffs.",
+    solution: "Create the continuation prompt FIRST, before researching. Structure the handoff upfront because you already know what you'll cover and what you'll defer. Then do the research. Then fill in the continuation prompt.",
+    keyInsight: "This single pattern solved the most frustrating problem in multi-session AI work: context loss across rate limits and session boundaries.",
+  },
+  {
+    id: "branch-chaining",
+    number: 8,
+    name: "Branch Chaining Strategy",
+    source: "gmail-organizer session (Features 1-20)",
+    problem: "Building 20 features sequentially means each branch needs the previous features, but branching from main means constant merge conflicts.",
+    solution: "Each feature branch is based on the PREVIOUS feature branch, creating a chain. Merge one at a time into main starting from the first; each subsequent PR automatically gets a smaller diff.",
+    keyInsight: "This turns a 20-feature build into a clean linear pipeline instead of a merge conflict nightmare.",
+  },
+  {
+    id: "quality-gate",
+    number: 9,
+    name: "Quality Gate Prompt",
+    source: "Cross-cutting from all production sessions",
+    problem: "Without explicit quality criteria, agents produce inconsistent output quality.",
+    solution: "Combine all quality requirements into a single reusable gate: no placeholder code, portfolio-presentable, no bugs/security issues, all pipelines pass, works end-to-end, documentation complete.",
+    keyInsight: "Measurable criteria ('80% test coverage') produce better results than subjective criteria ('make it good'). Agents treat explicit standards as hard requirements.",
+    template: `NEVER use: any, @ts-ignore, eslint-disable, console.log, alert(), // TODO
+ALWAYS use: Proper TypeScript interfaces, error handling (try/catch), cn() for classnames, Zod for validation`,
+  },
+  {
+    id: "context-recovery",
+    number: 10,
+    name: "Context Recovery / Session Continuation",
+    source: "save-a-stray and gmail-organizer (auto-generated)",
+    problem: "Sessions run out of context, and resuming loses all prior state, decisions, and progress.",
+    solution: "Generate structured summaries including: chronological analysis, key decisions, files modified, primary intent, technical concepts, errors and fixes, all user messages, pending tasks, current work state, and recommended next step.",
+    keyInsight: "Structured recovery prompts let agents resume with 90%+ context fidelity. The key is including ALL user messages (quoted) so the new session understands not just what happened, but why.",
+  },
+]
+
+// ============================================
+// WORKFLOW COMBINATIONS
+// ============================================
+
+export const workflowCombinations = [
+  {
+    name: "New Project (Full Pipeline)",
+    steps: ["Project Generator Meta-Prompt", "Research Prompt (continuation-first)", "Build Prompt (two-phase init)", "Iterative Multi-Phase Development", "Mass Feature Build", "3-Pass Code Review", "Merge to main"],
+  },
+  {
+    name: "Existing Project (Add Features)",
+    steps: ["Define feature list", "Mass Feature Build", "Documentation-Per-MR", "3-Pass Code Review", "Quality Gate", "Merge"],
+  },
+  {
+    name: "Code Review Only",
+    steps: ["3-Pass Code Review prompt", "Agent posts comments on PRs", "Agent fixes issues, creates fix PR", "Final merge"],
+  },
+]
+
+// ============================================
+// PRODUCTION AI PROJECTS
+// ============================================
+
+export const aiProjects: AIProject[] = [
+  {
+    id: "research-agent",
+    name: "Research Agent",
+    status: "Production (65 PRs, 97.7% coverage)",
+    purpose: "Crash-resilient deep research automation replacing manual browser-based research",
+    innovation: "Autonomous multi-node orchestration with atomic checkpoint resumption. Prompt caching reduces tokens by 83.9%.",
+    aiFeatures: ["Plan, Search, Scrape, Summarize, Synthesize pipeline", "Atomic checkpoint resumption on failures", "83.9% token reduction via prompt caching", "3-tier model routing (Fast/Smart/Strategic)", "4-level provider fallback chain"],
+    stack: ["LangGraph 1.0", "FastAPI", "ChromaDB", "nomic-embed-text", "Tavily API", "SQLAlchemy 2.0"],
+  },
+  {
+    id: "codereview-ai",
+    name: "CodeReview AI",
+    status: "MVP (Phase 1)",
+    purpose: "Self-hostable AI code reviews with zero data retention",
+    innovation: "BYOK (Bring Your Own Key) model. Users provide their own API keys; code is never retained after review.",
+    aiFeatures: ["Multi-provider: OpenAI GPT-4, Claude, Gemini, Ollama", "Webhook-triggered on PR creation", "Structured JSON review comments", "Per-repo .codereview.yaml config", "AES-256-GCM key encryption"],
+    stack: ["Next.js 14", "Strapi 5", "Express 5", "BullMQ", "Redis", "PostgreSQL"],
+  },
+  {
+    id: "patent-intelligence",
+    name: "Patent Intelligence",
+    status: "Production (Phase 10/10)",
+    purpose: "AI-powered patent research across 200M+ global patents",
+    innovation: "Vector semantic search with PatentSBERTa embeddings (768-dim) stored in pgvector. White space discovery for unpatented technology gaps.",
+    aiFeatures: ["PatentSBERTa embeddings + pgvector search", "AI idea generation via Claude/GPT-4", "White space analysis", "Citation network visualization", "Expiration intelligence"],
+    stack: ["Python 3.11+", "FastAPI", "PostgreSQL 16", "pgvector", "Redis", "React 18", "Celery"],
+  },
+  {
+    id: "spectree",
+    name: "SpecTree (Blueprint Builder)",
+    status: "Active Development",
+    purpose: "Transform ideas into structured, actionable work items using AI",
+    innovation: "AI generates tailored questions to refine requirements. Context propagates hierarchically from Epics to Features to User Stories to Tasks.",
+    aiFeatures: ["AI-generated clarifying questions", "Hierarchical context propagation", "Multi-provider: GPT-4, Claude, Gemini", "Progressive requirement refinement", "Granularity guidelines (stories ~1 week, tasks ~1 day)"],
+    stack: ["Next.js 14", "Strapi 5", "Express.js", "PostgreSQL"],
+  },
+  {
+    id: "jarvis",
+    name: "Jarvis Voice Assistant",
+    status: "Advanced Development (Full Duplex)",
+    purpose: "Production-grade offline voice assistant with <500ms latency",
+    innovation: "Full duplex conversation via PersonaPlex AI. Simultaneous talking and listening with natural interruption support, not turn-based.",
+    aiFeatures: ["Full duplex conversation (<500ms)", "Natural interruption support", "Back-channeling ('mm-hmm', 'yeah')", "3 modes: Full Duplex, Hybrid, Legacy", "Smart Home integration via Home Assistant"],
+    stack: ["Swift (macOS menu bar)", "Python orchestrator", "PersonaPlex-7b-v1", "Qwen 2.5 (7b/32b/72b)", "Whisper Large", "Docker"],
+  },
+  {
+    id: "gmail-organizer",
+    name: "Gmail Organizer",
+    status: "Active Development",
+    purpose: "AI-powered email classification and organization",
+    innovation: "9-worker parallel multi-account sync with Claude-powered classification and semantic search by meaning.",
+    aiFeatures: ["Claude-powered email classification", "Semantic search by meaning", "Smart filter creation with AI", "Gmail History API for incremental updates", "9-worker parallel sync"],
+    stack: ["Swift (macOS menu bar)", "Python", "Claude API", "Gmail API"],
+  },
+  {
+    id: "voiceforge",
+    name: "VoiceForge",
+    status: "Production",
+    purpose: "Voice cloning from 3-second audio samples",
+    innovation: "100% local processing with zero cloud dependency. Voice design from text descriptions.",
+    aiFeatures: ["Qwen3-TTS with PyTorch Metal GPU", "Voice cloning from 3-second samples", "Voice design from text descriptions", "6 preset voices + custom design", "10+ language support"],
+    stack: ["Python", "PyTorch", "Qwen3-TTS", "Metal GPU"],
+  },
+  {
+    id: "readforge",
+    name: "ReadForge",
+    status: "Production",
+    purpose: "Cross-platform privacy-first text-to-speech with AI voice quality",
+    innovation: "Kokoro-82M (ranked #1 on TTS Arena). Voice cloning from 10-second samples. 8 platforms, 0 cloud dependency.",
+    aiFeatures: ["Kokoro-82M (#1 TTS Arena)", "Voice cloning via F5-TTS (10s samples)", "Voice design via Qwen3-TTS", "ONNX Runtime on-device", "Metal GPU acceleration"],
+    stack: ["Swift", "C#", "Rust/GTK4", "ONNX Runtime", "Kokoro-82M"],
+  },
+  {
+    id: "writeforge",
+    name: "WriteForge",
+    status: "Active Development",
+    purpose: "Privacy-first AI-powered grammar checking",
+    innovation: "Local Qwen2.5 models: 0.5B in browser via WebLLM, 1.5B on desktop via llama.cpp. No data ever leaves the device.",
+    aiFeatures: ["Local Qwen2.5 (0.5B browser, 1.5B desktop)", "LanguageTool (30+ languages)", "Tone detection (formal/casual/confident)", "Cross-platform: browser + desktop"],
+    stack: ["WebLLM", "llama.cpp", "Swift", "C#", "Rust/GTK4", "LanguageTool"],
+  },
+  {
+    id: "genomeforge",
+    name: "GenomeForge",
+    status: "Development",
+    purpose: "Privacy-first genetic analysis",
+    innovation: "DNA never leaves the device. ClinVar database (341K+ variants), PharmGKB (715+ drug-gene interactions), AI genetic counselor via BYOK or Ollama.",
+    aiFeatures: ["Local processing (DNA on-device only)", "ClinVar (341K+ clinical variants)", "PharmGKB (715+ drug-gene interactions)", "AI genetic counselor (BYOK/Ollama)", "AES-256-GCM encryption with PBKDF2"],
+    stack: ["React", "Python", "Ollama", "ClinVar", "PharmGKB"],
+  },
+  {
+    id: "videovault",
+    name: "VideoVault",
+    status: "Production",
+    purpose: "Cross-platform video transcription and summarization",
+    innovation: "Native macOS app combining yt-dlp, ffmpeg, whisper-cpp, and LLM summarization in a single pipeline. Downloads, transcribes, and summarizes YouTube videos locally.",
+    aiFeatures: ["Whisper-cpp transcription (Metal GPU)", "LLM-powered video summarization", "Combined download/transcribe/summarize pipeline", "15-second transcription for 12-minute videos"],
+    stack: ["Swift (macOS)", "Python (Windows)", "whisper-cpp", "yt-dlp", "ffmpeg"],
+  },
+]
+
+// ============================================
+// MULTI-LLM STRATEGY
+// ============================================
+
+export const llmProviders: LLMProvider[] = [
+  { tier: "Primary", provider: "Anthropic Claude", models: "Opus, Sonnet, Haiku", useCase: "Complex reasoning, code generation, architecture" },
+  { tier: "Fallback 1", provider: "OpenAI", models: "GPT-4o, GPT-4-turbo", useCase: "Cost optimization, broad compatibility" },
+  { tier: "Fallback 2", provider: "Google Gemini", models: "Gemini 2.0, 1.5 Pro", useCase: "Budget tier, research assistance" },
+  { tier: "Offline", provider: "Ollama (Local)", models: "Qwen 2.5 (7b-72b)", useCase: "Privacy, cost, no internet required" },
+]
+
+export const modelRoutingTiers = [
+  { tier: "FAST", description: "Quick, straightforward tasks", models: "Smaller models (Haiku, GPT-4o-mini, Flash)" },
+  { tier: "SMART", description: "Moderate complexity", models: "Mid-range models (Sonnet, GPT-4o)" },
+  { tier: "STRATEGIC", description: "Complex reasoning", models: "Largest models (Opus, GPT-4-turbo)" },
+]
+
+export const tokenOptimizations = [
+  { technique: "Prompt Caching", result: "83.9% token reduction in Research Agent" },
+  { technique: "Structured Output", result: "Pydantic models prevent wasted tokens on malformed responses" },
+  { technique: "Token Counting", result: "TikToken for real-time cost tracking and estimation" },
+  { technique: "Context Compression", result: "Long conversations compressed to preserve key information" },
+]
+
+export const llmPipelineDiagram = `User Input
+    |
+API Gateway / Express Middleware
+    |
+Rate Limiting + Key Rotation
+    |
+Provider Selection (primary -> fallback chain)
+    |
+Prompt Template + Context Injection
+    |
+LLM API Call (retry + exponential backoff)
+    |
+Response Parsing (JSON schema validation)
+    |
+Result Caching + Cost Logging
+    |
+User Output`
+
+// ============================================
+// VOICE-FIRST AI
+// ============================================
+
+export const voiceProjects: VoiceProject[] = [
+  { project: "Jarvis", technology: "PersonaPlex + Ollama + Whisper", latency: "<500ms", keyFeature: "Full duplex conversation" },
+  { project: "VoiceForge", technology: "Qwen3-TTS + PyTorch Metal", latency: "Real-time", keyFeature: "Voice cloning from 3s sample" },
+  { project: "ReadForge", technology: "Kokoro-82M + ONNX Runtime", latency: "Real-time", keyFeature: "#1 TTS Arena quality" },
+  { project: "VideoVault", technology: "Whisper-cpp + Metal GPU", latency: "15s/12min", keyFeature: "Video transcription pipeline" },
+  { project: "Voice Docs", technology: "Browser Speech API", latency: "Native", keyFeature: "Zero external dependencies" },
+]
+
+export const jarvisArchitectureDiagram = `Swift macOS Menu Bar App (Option+Space hotkey)
+           |
+Python Orchestrator Server (port 5001)
+    |         |         |         |
+PersonaPlex VoiceForge Ollama  Home Assistant
+ (8998)      (8765)    (11434)  Integration`
+
+export const jarvisOperatingModes = [
+  { mode: "Full Duplex", engine: "PersonaPlex", latency: "<500ms", description: "Natural conversation with interruption support" },
+  { mode: "Hybrid", engine: "PersonaPlex + Ollama", latency: "500ms-3s", description: "PersonaPlex for simple, Ollama for complex queries" },
+  { mode: "Legacy", engine: "Ollama only", latency: "2-5s", description: "STT then LLM then TTS sequential pipeline" },
+]
+
+// ============================================
+// PRIVACY-FIRST PHILOSOPHY
+// ============================================
+
+export const privacyProjects: PrivacyProject[] = [
+  { project: "Jarvis Voice Assistant", approach: "Ollama runs 100% locally (up to 72B parameters)" },
+  { project: "ReadForge", approach: "100% local TTS, text never transmitted to any server" },
+  { project: "WriteForge", approach: "Local Qwen2.5 models, LanguageTool runs locally" },
+  { project: "VoiceForge", approach: "Zero cloud dependency for voice cloning" },
+  { project: "GenomeForge", approach: "DNA never leaves device, AES-256-GCM encryption" },
+  { project: "Voice Docs", approach: "Browser Speech API, no external calls" },
+  { project: "CodeReview AI", approach: "BYOK model, zero code retention after review" },
+]
+
+export const byokDescription = `Users provide their own API keys. The platform never stores, processes, or retains user data beyond the immediate operation. This is a fundamental architectural decision, not a feature toggle. When you combine BYOK with local model support (Ollama), you get a system that works from fully online to completely air-gapped, all from the same codebase.`
+
+// ============================================
+// CROSS-MACHINE WORKFLOW
+// ============================================
+
+export const machines = [
+  { name: "Mac (Office)", hardware: "Apple M2 Max, 96GB RAM", bestFor: "Large models (72B), primary development" },
+  { name: "Windows (Garage)", hardware: "i7-8700K, 32GB RAM, RTX 2070", bestFor: "7B-14B models, CUDA acceleration, secondary dev" },
+]
+
+export const agentSyncProtocol = [
+  { file: "CONTEXT.md", purpose: "Real-time machine inventory and software status" },
+  { file: "QUESTIONS.md", purpose: "Q&A between Mac and Windows agents" },
+  { file: "CONVERSATION.md", purpose: "Chronological log of agent communications" },
+]
+
+export const syncWorkflow = `SESSION START:
+1. git pull origin main (on all project repos)
+2. Check agent-sync for cross-machine updates
+3. Check global-todo for task priorities
+
+SESSION END:
+1. Update agent-sync with session results
+2. Update global-todo with completed/new tasks
+3. Commit and push all changes`
+
+// ============================================
+// QUALITY ENGINEERING
+// ============================================
+
+export const qualityMetrics: QualityMetric[] = [
+  { metric: "Unit Tests", minimum: "80%" },
+  { metric: "Integration Tests", minimum: "80%" },
+  { metric: "E2E Tests", minimum: "80% of critical paths" },
+  { metric: "Branch Coverage", minimum: "80%" },
+  { metric: "Function Coverage", minimum: "80%" },
+  { metric: "Line Coverage", minimum: "80%" },
+]
+
+export const codeStandards = [
+  "No hardcoded user paths (use ~, $HOME, environment variables)",
+  "No 'any' types in TypeScript (proper typing or generics)",
+  "No placeholder functionality (delete commented code, don't ship stubs)",
+  "Cyclomatic complexity limits (max 3 nesting levels, functions under 30-40 lines)",
+  "Lookup tables instead of if-else chains",
+  "Early returns instead of nested conditions",
+  "Every code file has a corresponding test file",
+  "CI pipeline blocks merging if any metric falls below threshold",
+]
+
+export const gitWorkflow = [
+  "Never push directly to main (feature branches only)",
+  "Feature branches: feature/descriptive-name or fix/descriptive-name",
+  "Create PRs with gh pr create",
+  "Wait for CI + code review before merge",
+  "Never close PRs due to merge conflicts (resolve them instead)",
+  "3-pass code review before final merge",
+]
+
+// ============================================
+// AI CODING TOOLS
+// ============================================
+
+export const aiTools: AITool[] = [
+  { name: "Claude Code", stats: "273 sessions, 590KB history, 738+ todos", purpose: "Primary development agent for code generation, architecture, debugging, and autonomous multi-phase builds" },
+  { name: "GitHub Copilot", stats: "Multiple versions installed", purpose: "IDE-level code completion and inline suggestions during manual coding" },
+  { name: "Cursor", stats: "24,407 files (~436MB context)", purpose: "AI IDE with full project context awareness for targeted edits" },
+  { name: "Gemini / Google AI", stats: "235MB working data", purpose: "Research, search, and exploration tasks" },
+]
+
+export const claudeCodeConfig = `13 configuration files totaling ~101KB of rules and context:
+- Global CLAUDE.md (22KB): Master ruleset for all projects
+- Enterprise Template: 8 specialized files (50KB+)
+  - Project context, workflow rules, verification rules
+  - Prompt/SDD rules, testing/memories, integration
+  - Render infrastructure management
+- Project-specific: Jarvis (5.5KB), Dev Environment (1.7KB)
+- Memory file: Persistent learnings across sessions`
+
+// ============================================
+// PRACTICAL USE CASES
+// ============================================
+
+export const useCases: UseCase[] = [
+  {
+    id: "youtube-transcription",
+    title: "YouTube Video Transcription",
+    description: "Download, convert, and transcribe YouTube videos locally using GPU acceleration. ~15 seconds for a 12-minute video on M2 Max.",
+    codeSnippet: `# Download audio
+yt-dlp -x --audio-format wav -o "audio.%(ext)s" "URL"
+# Convert to 16kHz mono (whisper-cpp requirement)
+ffmpeg -y -i audio.wav -ar 16000 -ac 1 -c:a pcm_s16le audio_16k.wav
+# Transcribe with Metal GPU acceleration
+whisper-cli -m ggml-small.en.bin -f audio_16k.wav -otxt`,
+  },
+  {
+    id: "pdf-conversion",
+    title: "PDF to Text for LLM Input",
+    description: "Convert large PDFs to text files for uploading to Claude Desktop. Dramatically reduces file size (51MB PDF to 85KB text) while preserving content.",
+    codeSnippet: `pdftotext ~/path/to/input.pdf ~/path/to/output.txt
+# 51MB PDF -> 85KB text, suitable for Claude Desktop`,
+  },
+  {
+    id: "email-classification",
+    title: "AI-Powered Email Classification",
+    description: "9-worker parallel system using Claude to classify emails across multiple Gmail accounts with semantic search. Uses Gmail History API for incremental updates.",
+  },
+  {
+    id: "video-archival",
+    title: "Video Archival Pipeline",
+    description: "Native macOS app combining yt-dlp, ffmpeg, whisper-cpp, and LLM summarization. Downloads, transcribes, and generates summaries in a single automated pipeline.",
+  },
+  {
+    id: "voice-home-control",
+    title: "Smart Home Voice Control",
+    description: "Voice commands through Jarvis control smart home devices via Home Assistant REST API. Full natural language understanding processed locally through PersonaPlex or Ollama.",
+  },
+  {
+    id: "automated-code-review",
+    title: "Automated PR Code Reviews",
+    description: "Webhook-triggered code reviews on PR creation. AI analyzes diffs, generates structured comments with line references, and posts them directly to the PR. Supports 4 AI providers and 4 Git platforms.",
+  },
+  {
+    id: "enterprise-prompts",
+    title: "Production Prompt Engineering (36 Prompts)",
+    description: "836KB of deployment-ready prompts from enterprise client work covering: RBAC integration, media library management, CMS operations, Docker build context, database seeding, environment verification, Sentry monitoring, package dependency verification, and calendar system design (70KB alone).",
+  },
+]
+
+// ============================================
+// ENTERPRISE PATTERNS
+// ============================================
+
+export const enterprisePatterns: EnterprisePattern[] = [
+  {
+    title: "Multi-Agent Work Tracking",
+    description: "Automated epic creation and bug handling with natural language trigger detection.",
+    details: [
+      "Epic triggers: 'let's create new functionality', 'build [feature name]', 'start new epic'",
+      "Bug triggers: 'there's a bug', 'fix this issue', 'something is broken'",
+      "5-minute requirements gathering using simplified template",
+      "Automated setup script creates folder structure, templates, and tracking files",
+      "Token usage target: 500-800 tokens for setup (not 15,000+)",
+    ],
+  },
+  {
+    title: "Software Design Document (SDD) Automation",
+    description: "AI assistants automatically create versioned SDDs before implementing features with 3+ components.",
+    details: [
+      "SDDs versioned with major/minor/patch increments",
+      "Automatic triggers: architecture mods, DB changes, API changes, business logic updates",
+      "Structured directory hierarchy per feature",
+      "Includes: system overview, technical architecture, implementation details, testing strategy, deployment considerations",
+    ],
+  },
+  {
+    title: "Demo Mode Pattern",
+    description: "All portfolio applications with authentication implement demo mode for showcasing without real API keys.",
+    details: [
+      "Marketing pages identical in both modes",
+      "Demo diverges at auth: real auth vs demo role selector",
+      "Middleware checks DEMO_MODE before any auth provider logic",
+      "Always shows demo banner so users know they're in demo mode",
+      "render.yaml sets DEMO_MODE=true for all portfolio deployments",
+    ],
+  },
+  {
+    title: "Verification Script System",
+    description: "Every new feature gets an automated verification script checking completeness.",
+    details: [
+      "File structure verification (all required files exist)",
+      "Documentation verification (all docs updated)",
+      "Integration points (routes, exports, type system)",
+      "Code quality (no placeholders, proper error handling, TypeScript compliance)",
+      "Run at milestones: after implementation, before completion, during review, before deploy",
+    ],
+  },
+]
+
+// ============================================
+// ADVANCED PROMPT ENGINEERING
+// ============================================
+
+export const advancedPatterns = [
+  { name: "Structured JSON Output", description: "Explicit format specifications in prompts ensure parseable, consistent responses from LLMs. Every prompt specifies the exact JSON schema expected." },
+  { name: "Separator Pattern", description: "Uses '=+=' to separate multiple JSON objects in a single response, preventing concatenation issues when asking for multiple structured outputs." },
+  { name: "Deduplication Strategy", description: "Existing items included in prompts with instructions to avoid repeating them. Prevents LLMs from regenerating content that already exists." },
+  { name: "Context Injection", description: "Dynamic variable substitution into prompt templates. Context flows from parent items (Epic context injected into Feature prompts, Feature context into Story prompts)." },
+  { name: "Granularity Guidelines", description: "User Stories scoped to '~1 week of work', Tasks scoped to '~1 day of work'. Consistent sizing produces predictable AI-generated work items." },
+  { name: "Multi-Step Prompt Chains", description: "Sequential prompt chains where each level builds on previous outputs: Epic, then Feature, then User Story, then Task. Progressive refinement at each level." },
+]
+
+// ============================================
+// LESSONS LEARNED
+// ============================================
+
+export const lessonsLearned: Lesson[] = [
+  {
+    number: 1,
+    title: "Separation of Concerns is Critical",
+    insight: "Prompts stored separately from project code prevents agents from modifying their own instructions. This was discovered through painful experience and is now a foundational principle of the entire system.",
+  },
+  {
+    number: 2,
+    title: "Continuation-First Approach Solves Context Loss",
+    insight: "Creating handoff prompts BEFORE doing research ensures context is preserved across rate limits and session boundaries. Doing it afterward consistently leads to incomplete handoffs and lost knowledge.",
+  },
+  {
+    number: 3,
+    title: "Multi-LLM Fallback is Essential for Production",
+    insight: "No single LLM provider has 100% uptime or handles all tasks optimally. Primary/fallback chains with graceful degradation ensure your system keeps working regardless of any single provider's status.",
+  },
+  {
+    number: 4,
+    title: "Quality Gates Must Be Automated and Non-Negotiable",
+    insight: "80% coverage thresholds, mandatory test files, CI pipeline blocks, and 3-pass code reviews prevent technical debt from accumulating. When quality is optional, it disappears under deadline pressure.",
+  },
+  {
+    number: 5,
+    title: "Voice is the Next Interface Paradigm",
+    insight: "Full duplex conversation with <500ms latency fundamentally changes how humans interact with AI. Turn-based chat is useful but limiting. Natural conversation with interruption support feels like a completely different technology.",
+  },
+  {
+    number: 6,
+    title: "Privacy is a Feature, Not a Constraint",
+    insight: "Local-first, BYOK architectures are competitive advantages, not compromises. Users increasingly want tools that keep their data on their devices. Building for privacy from day one is easier than retrofitting it later.",
+  },
+  {
+    number: 7,
+    title: "Agents Work Best with Explicit, Measurable Criteria",
+    insight: "Vague instructions produce vague results. 'Make it good' fails; '80% test coverage, all pipelines passing, documentation updated, portfolio-presentable' succeeds. The more specific the prompt, the better the output.",
+  },
+  {
+    number: 8,
+    title: "Knowledge Preservation is a System, Not an Afterthought",
+    insight: "273 sessions consolidated, 738 todos tracked, structured WORK_LOG files, and auto-generated context recovery prompts. Knowledge preservation must be built into the workflow, not bolted on after the fact.",
+  },
+  {
+    number: 9,
+    title: "Meta-Prompts Compound Value Exponentially",
+    insight: "A prompt that generates other prompts (meta-prompt) pays dividends across every project it touches. The 95KB PROJECT_GENERATOR_PROMPT has been used to bootstrap 77+ projects, each with consistent quality and structure.",
+  },
+  {
+    number: 10,
+    title: "Human-in-the-Loop is the Sweet Spot",
+    insight: "Fully autonomous AI development isn't the goal. Human judgment at key decision points (architecture, feature prioritization, design trade-offs) combined with AI execution of well-defined tasks produces the best results. The ecosystem is designed for augmentation, not replacement.",
+  },
+]

--- a/src/data/ai-development.ts
+++ b/src/data/ai-development.ts
@@ -93,11 +93,14 @@ export const aiStats: AIStat[] = [
   { label: "Projects with AI Prompts", value: "77+", description: "Each with structured agent prompt infrastructure" },
   { label: "Production AI Products", value: "11", description: "Shipped, working AI-powered applications" },
   { label: "Reusable Prompt Patterns", value: "10", description: "Battle-tested across dozens of projects" },
-  { label: "Total AI Sessions", value: "560+", description: "Across Claude, Gemini, Codex, Cursor, and ChatGPT" },
+  { label: "Total AI Sessions", value: "620+", description: "Across Claude, Gemini, Codex, Cursor, Copilot, and ChatGPT" },
   { label: "Enterprise Prompts", value: "36", description: "Production prompts from client work (836KB)" },
-  { label: "Conversation Data", value: "19.7 GB", description: "Raw AI interaction data across all tools" },
-  { label: "Git Commits", value: "4,442", description: "Across 53 repositories spanning 2019-2026" },
-  { label: "Market Research Reports", value: "11", description: "Full competitive intelligence with validated unit economics" },
+  { label: "Conversation Data", value: "16.2 GB", description: "Raw AI interaction data across all tools" },
+  { label: "Tokens Processed", value: "10.7B", description: "Through Claude Code alone (351K+ messages)" },
+  { label: "Git Commits", value: "4,284", description: "Across 58 repositories spanning 2019-2026" },
+  { label: "Market Research Reports", value: "15", description: "Full competitive intelligence with validated unit economics" },
+  { label: "Development Acceleration", value: "58x", description: "Commit velocity increase: 429/yr to 25,035/yr projected" },
+  { label: "Demo Mode Apps", value: "23", description: "Portfolio apps with standardized demo mode pattern" },
   { label: "Test Coverage", value: "97.7%", description: "Research Agent branch coverage" },
 ]
 
@@ -570,13 +573,13 @@ export const gitWorkflow = [
 // ============================================
 
 export const aiTools: AITool[] = [
-  { name: "Claude Code CLI", stats: "330 sessions, 9.1 GB data, 4,050 history commands", purpose: "Primary development agent. Largest session: 1.53 GB. Peak: 15 simultaneous instances. Autonomous multi-phase builds with --dangerously-skip-permissions." },
-  { name: "Gemini CLI", stats: "41 sessions, 613 MB brain data", purpose: "Portfolio-specific work (games, visual features). Built Mafia Wars recreation (245 MB session, 10 phases), portfolio rebuild (111 MB, 17 phases). Identical code standards enforced via GEMINI.md." },
-  { name: "OpenAI Codex CLI", stats: "44 sessions, 248 MB, model gpt-5.2-codex", purpose: "Bulk parallel processing. Peak day: 12 sessions in one day across patent-intelligence, TreasureTrail, ChoreChamp, SpecTree, save-a-stray, ink-synthesis." },
-  { name: "Cursor IDE", stats: "49 workspace roots, 2.2 GB data, AI tracking DB", purpose: "AI-native VS Code fork with full project context. MCP integration for Render deployment management." },
-  { name: "GitHub Copilot Chat", stats: "5 versions installed (VS Code + Cursor)", purpose: "IDE-level code completion, inline suggestions, and chat-based assistance during manual coding." },
+  { name: "Claude Code CLI", stats: "398 sessions, 9.1 GB, 351K messages, 10.7B tokens", purpose: "Primary development agent. 54,970 tool calls. Peak day: 37,202 messages across 39 sessions. Longest session: 90 hours / 3,922 messages. Largest: 1.55 GB (CodeReview AI MVP)." },
+  { name: "Gemini CLI", stats: "140 sessions, 6.9 GB data", purpose: "Portfolio work (games, visual features), browser automation with 14 recordings, image generation. Identical code standards enforced via GEMINI.md referencing CLAUDE.md." },
+  { name: "OpenAI Codex CLI", stats: "44 sessions, 255 MB, gpt-5.2-codex (xhigh reasoning)", purpose: "Autonomous bulk processing. 'Do not stop until done' pattern across 10+ projects in one day. Peak: 12 sessions across patent-intelligence, TreasureTrail, ChoreChamp, SpecTree." },
+  { name: "Cursor IDE", stats: "3 workspaces, 695 MB, 4,099 file history entries", purpose: "AI-native VS Code fork with full project context. MCP integration for Render deployment management." },
+  { name: "VS Code / Copilot", stats: "177 sessions (90 chat + 87 editing), 283 MB", purpose: "Quick in-editor completions across 182 workspaces. 23 Copilot chat directories tracked." },
   { name: "ChatGPT Desktop", stats: "macOS app with 69 extensions", purpose: "Supplementary research and exploration. Conversation exports backed up to Google Drive." },
-  { name: "Ollama", stats: "5 models, 187 GB+, up to 72B parameters", purpose: "Local model server for privacy-first development. Models: qwen2.5 (7B/32B/72B), dolphin-mistral:7b, qwen2.5-coder:32b." },
+  { name: "Ollama", stats: "5 models, 93 GB, up to 72B parameters", purpose: "Local model server for privacy-first development. Models: qwen2.5 (7B/32B/72B), dolphin-mistral:7b, qwen2.5-coder:32b." },
 ]
 
 export const toolDiversificationStrategy = `Each AI tool serves a specific role in the workflow:
@@ -916,6 +919,190 @@ export const googleDriveStats = {
   transcriptions: "46 VTT transcription files",
   backupArchives: "ran.zip (156.81 GB), Personal projects.zip (22.19 GB)",
   allAiWork: "40,408 items, 836 MB of AI development artifacts",
+}
+
+// ============================================
+// DEVELOPMENT ACCELERATION
+// ============================================
+
+export interface AccelerationStat {
+  period: string
+  commitsPerYear: string
+  reposCreated: string
+  note: string
+}
+
+export const developmentAcceleration: AccelerationStat[] = [
+  { period: "Pre-2026 (~6 years)", commitsPerYear: "~429/year avg", reposCreated: "16 total", note: "Manual development, traditional workflow" },
+  { period: "2026 (43 days)", commitsPerYear: "~25,035/year projected", reposCreated: "42 new repos", note: "AI-augmented pipeline at full velocity" },
+]
+
+export const accelerationDescription = `In just 43 days of 2026, 2,950 commits were produced across 42 new repositories. This exceeds all pre-2026 development combined (2,574 commits over ~6 years). The 58x acceleration in commit velocity is not from lower-quality commits; it comes from the AI-augmented pipeline handling scaffolding, testing, documentation, and deployment while human judgment focuses on architecture and feature prioritization.`
+
+// ============================================
+// CLAUDE CODE DETAILED STATS
+// ============================================
+
+export const claudeCodeDetailedStats = {
+  totalSessions: "398",
+  totalMessages: "351,546",
+  totalToolCalls: "54,970",
+  tokensProcessed: "~10.7 billion",
+  peakDayDate: "January 25, 2026",
+  peakDayMessages: "37,202",
+  peakDaySessions: "39",
+  peakDayToolCalls: "5,854",
+  longestSession: "90 hours / 3,922 messages",
+  largestSession: "1,547 MB (CodeReview AI MVP build)",
+  dataSize: "9.1 GB across all sessions",
+}
+
+// ============================================
+// SPECTREE EXPORT FORMATS
+// ============================================
+
+export interface ExportFormat {
+  name: string
+  format: string
+  description: string
+}
+
+export const specTreeExportFormats: ExportFormat[] = [
+  { name: "Cursor", format: ".cursor/rules/*.mdc", description: "Cursor IDE rule files for project-specific AI context" },
+  { name: "GitHub Copilot", format: ".github/copilot-instructions.md + WRAP", description: "Copilot workspace instructions with structured wrap format" },
+  { name: "Devin", format: "Atomic task specs", description: "Task-level specifications for Devin's autonomous execution" },
+  { name: "v0", format: "UI specs", description: "Frontend component specifications for v0 generation" },
+  { name: "CodeRabbit", format: ".coderabbit.yaml", description: "Automated code review configuration" },
+  { name: "Windsurf", format: ".windsurfrules XML", description: "Windsurf IDE workspace rules in XML format" },
+  { name: "Lovable", format: "Knowledge Base PRD", description: "Product requirement documents for Lovable's builder" },
+  { name: "MCP Server", format: "Real-time JSON API", description: "Live specification access via Model Context Protocol" },
+  { name: "Universal JSON", format: "JSON export", description: "Platform-agnostic structured export for custom integrations" },
+]
+
+// ============================================
+// NATIVE macOS MENU BAR APPS
+// ============================================
+
+export interface NativeMacApp {
+  name: string
+  purpose: string
+  features: string[]
+}
+
+export const nativeMacOSApps: NativeMacApp[] = [
+  { name: "AgentPromptsManager", purpose: "Agent prompts orchestration and management", features: ["17 Swift source files", "Global hotkeys (Cmd+Shift+I for new idea)", "CLI detection for Claude Code, Gemini, Codex", "URL scheme (agentprompts://) with 12+ actions", "FSEvents file watching", "Automated 5-phase workflow"] },
+  { name: "JarvisApp", purpose: "Voice assistant with full duplex conversation", features: ["Option+Space hotkey", "PersonaPlex integration", "3 operating modes", "Home Assistant smart home control"] },
+  { name: "VoiceForge/QwenTTS", purpose: "Text-to-speech with voice cloning", features: ["PyTorch Metal GPU acceleration", "Voice cloning from 3-second samples", "Voice design from text descriptions"] },
+  { name: "GmailOrganizerHelper", purpose: "AI-powered email classification", features: ["9-worker parallel sync", "Claude-powered classification", "Semantic search by meaning", "Multi-account support"] },
+]
+
+export const nativeMacAppPattern = `All 4 apps share a consistent architecture: LSUIElement (no dock icon), dark mode support, AppleScript/Terminal integration, and build.sh scripts for compilation. This pattern uses Swift/Cocoa for native macOS frontends that orchestrate Python or local AI backends.`
+
+// ============================================
+// PERSONAPLEX CROSS-PROJECT STRATEGY
+// ============================================
+
+export interface PersonaPlexProject {
+  project: string
+  voiceUseCase: string
+}
+
+export const personaplexProjects: PersonaPlexProject[] = [
+  { project: "Jarvis Voice Assistant", voiceUseCase: "Primary conversational AI with full duplex (<500ms)" },
+  { project: "CodeReview AI", voiceUseCase: "Voice-driven code review walkthroughs" },
+  { project: "Patent Intelligence", voiceUseCase: "Voice patent research and discovery queries" },
+  { project: "Gmail Organizer", voiceUseCase: "Voice email triage and classification" },
+  { project: "VoiceForge", voiceUseCase: "Conversational voice design and cloning interface" },
+  { project: "OBS Tutorial Recorder", voiceUseCase: "Voice narration during screen recordings" },
+]
+
+export const personaplexDescription = `PersonaPlex (NVIDIA, <500ms full duplex) validated on Mac M2 Max with 96GB unified memory. Planned integration across 6+ projects, creating a consistent voice-first interface layer. Detailed analysis at PERSONAPLEX_UPGRADE_ANALYSIS.md (18 KB).`
+
+// ============================================
+// KNOWLEDGE INGESTION PIPELINE
+// ============================================
+
+export const knowledgeIngestionPipeline = {
+  youtubeSessions: "68",
+  pattern: "Download via yt-dlp, convert with ffmpeg, transcribe with whisper-cpp (Metal GPU), summarize with LLM",
+  purpose: "Systematic knowledge ingestion from YouTube into a personal knowledge base and NAS media library",
+  toolchain: "yt-dlp + ffmpeg + whisper-cpp + Claude/Ollama summarization",
+  speed: "~15 seconds transcription for a 12-minute video on M2 Max",
+}
+
+export const tutorialRecordings = [
+  { date: "2026-01-18", subject: "Building CodeReview AI", description: "OBS screen recording of the full build process for CodeReview AI application" },
+  { date: "2026-01-18", subject: "New App Process", description: "Recording of new project creation using the agent prompts system workflow" },
+  { date: "2026-01-21", subject: "Gmail Organizer Work", description: "Recording of Gmail Organizer development session" },
+]
+
+export const tutorialRecordingsDescription = `13 OBS screen recording sessions documenting the AI workflow system in action. These recordings serve as video evidence of the agent-augmented development process, capturing real builds from idea to deployment.`
+
+// ============================================
+// COST OPTIMIZATION PATTERNS
+// ============================================
+
+export interface CostPattern {
+  technique: string
+  result: string
+  project: string
+}
+
+export const costOptimizationPatterns: CostPattern[] = [
+  { technique: "Prompt Caching", result: "83.9% token reduction", project: "Research Agent" },
+  { technique: "3-Tier Model Routing", result: "Route simple tasks to cheap models, complex to expensive", project: "Research Agent" },
+  { technique: "Free Tier Harvesting", result: "Render free tier for static sites, PostgreSQL, Redis", project: "All portfolio projects" },
+  { technique: "Haiku/Sonnet Splitting", result: "Use Haiku for classification, Sonnet for reasoning", project: "Gmail Organizer" },
+  { technique: "Session Cost Tracking", result: "$0.06-0.15/session (96-97% cost reduction vs naive)", project: "Research Agent" },
+  { technique: "Token Counting", result: "TikToken for real-time cost estimation before API calls", project: "Multiple" },
+]
+
+// ============================================
+// CROSS-TOOL INSTRUCTION SYNC
+// ============================================
+
+export const crossToolSyncDescription = `A single source of truth (~/.claude/CLAUDE.md) synchronizes instructions across all AI tools. Gemini's config explicitly references it. Codex sessions were configured to always look at that file. This means updating one file propagates rules (forbidden patterns, git workflow, testing requirements) to all agents regardless of which tool runs them.`
+
+export const crossToolSyncEvidence = [
+  { tool: "Gemini CLI", method: "GEMINI.md references CLAUDE.md directly", quote: "Please also refer to the global agent instructions located at CLAUDE.md" },
+  { tool: "Codex CLI", method: "Configured to reference at session start", quote: "Can you just reference to always look at that file the Claude MD so I only have to worry about updating that one file" },
+  { tool: "Claude Code", method: "Native CLAUDE.md loading", quote: "Loaded automatically at every session start" },
+  { tool: "Cursor IDE", method: "MCP integration", quote: "Project context loaded via workspace configuration" },
+]
+
+// ============================================
+// ENFORCEMENT GAPS (Honest Self-Assessment)
+// ============================================
+
+export interface EnforcementGap {
+  policy: string
+  stated: string
+  actual: string
+}
+
+export const enforcementGaps: EnforcementGap[] = [
+  { policy: "80% Test Coverage", stated: "NON-NEGOTIABLE. NO EXCEPTIONS.", actual: "All Codecov configs use informational: true (reporting only, never blocks)" },
+  { policy: "Pre-commit Hooks", stated: "Elaborate hooks in enterprise-template-system", actual: "Entirely commented out in the most sophisticated project" },
+  { policy: "TypeScript Strict", stated: "No any types mandate", actual: "Enterprise-template-system itself has strict: false in tsconfig" },
+  { policy: "E2E Testing in CI", stated: "80% of critical paths", actual: "Only 1 project has E2E tests in CI pipeline" },
+  { policy: "Test File Coverage", stated: "Every code file must have a corresponding test file", actual: "31 of 59 projects have zero test files" },
+]
+
+export const enforcementGapsDescription = `An honest assessment of gaps between stated policy and actual enforcement. These gaps exist because the ecosystem scaled from 16 to 58 repos in 43 days. The policies were written first (design-first), and enforcement tooling is being propagated. The gaps are documented, tracked, and being addressed systematically.`
+
+// ============================================
+// ADDITIONAL NOTABLE PROJECTS
+// ============================================
+
+export const additionalFindings = {
+  geneticHealthPipeline: "Cross-referenced 667,120 SNPs against ClinVar (341K variants), PharmGKB, and GWAS Catalog (511 MB, 1M+ associations). 271,000+ genetic associations analyzed across 20 health categories, all processed locally.",
+  teamsTranscription: "387 Microsoft Teams meeting recordings (104 GB) from the startup period. 3 transcription engines compared: whisper-cpp (local), faster-whisper (local with speaker diarization), and OpenAI Whisper API (cloud).",
+  metaPromptEnhancement: "META_PROMPT_ENHANCE_EXCAVATION.md (34 KB): A prompt that improves prompts. This represents a third level of meta-prompting: prompts that generate prompts, AND prompts that improve prompt-generators.",
+  extractedPromptsLibrary: "392 KB of raw prompts extracted from production sessions, refined to 18 KB cleaned version, then curated to 16 KB reusable version. Three-stage prompt extraction pipeline.",
+  projectsArchiveDb: "187 MB SQLite queryable database of 224,228 files across 28,191 directories from 72 git repositories. Enables programmatic analysis of the full project archive.",
+  hivStrategy: "Active contractor work for HIVE Strategy (Diamond HubSpot Solutions Partner, top 4% globally). 3-pass code review applied to real client code: decomposed a 2,393-line file into 9 modules, a 1,106-line file into 11 sub-routers, fixed 146 console.* calls.",
+  stableDiffusion: "Full AUTOMATIC1111 Stable Diffusion WebUI installation for local AI image generation, adding to the portfolio of local-first AI tools.",
+  diffLocal: "DiffLocal: Content Security Policy headers restrict ALL network access. URL fragments never sent to server. Extreme privacy pattern where files stay within a strict boundary.",
 }
 
 // ============================================

--- a/src/pages/AIDevelopmentPage.tsx
+++ b/src/pages/AIDevelopmentPage.tsx
@@ -1,0 +1,804 @@
+import { useState } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import { Link } from "react-router-dom"
+import {
+  ArrowLeft, Brain, Bot, Shield, Mic, Terminal, Layers, Sparkles,
+  ChevronDown, ChevronRight, Code2, Zap, BookOpen, Wrench,
+  GitBranch, CheckCircle, Monitor, Lightbulb, ArrowRight, Lock,
+  Server,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  aiStats,
+  journeyTimeline,
+  ecosystemDescription,
+  ecosystemLayers,
+  qualityTriangle,
+  nonprofitStrategy,
+  agentPromptSystemDescription,
+  agentPromptWorkflow,
+  metaPrompts,
+  projectStructure,
+  promptPatterns,
+  workflowCombinations,
+  aiProjects,
+  llmProviders,
+  modelRoutingTiers,
+  tokenOptimizations,
+  llmPipelineDiagram,
+  voiceProjects,
+  jarvisArchitectureDiagram,
+  jarvisOperatingModes,
+  privacyProjects,
+  byokDescription,
+  machines,
+  agentSyncProtocol,
+  syncWorkflow,
+  qualityMetrics,
+  codeStandards,
+  gitWorkflow,
+  aiTools,
+  claudeCodeConfig,
+  useCases,
+  enterprisePatterns,
+  advancedPatterns,
+  lessonsLearned,
+} from "@/data/ai-development"
+
+// ============================================
+// Reusable Sub-Components
+// ============================================
+
+function CollapsibleSection({
+  title,
+  icon: Icon,
+  children,
+  defaultOpen = false,
+  id,
+}: {
+  title: string
+  icon: React.ComponentType<{ className?: string }>
+  children: React.ReactNode
+  defaultOpen?: boolean
+  id: string
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+
+  return (
+    <motion.section
+      id={id}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-50px" }}
+      className="mb-8"
+    >
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center gap-3 p-5 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:bg-card/80 hover:border-primary/30 transition-all text-left group"
+      >
+        <div className="p-2 rounded-lg bg-primary/10 text-primary">
+          <Icon className="h-5 w-5" />
+        </div>
+        <h2 className="text-xl md:text-2xl font-bold flex-1">{title}</h2>
+        <motion.div
+          animate={{ rotate: isOpen ? 180 : 0 }}
+          transition={{ duration: 0.2 }}
+        >
+          <ChevronDown className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
+        </motion.div>
+      </button>
+
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            className="overflow-hidden"
+          >
+            <div className="p-6 md:p-8 border border-t-0 border-border/50 rounded-b-xl bg-card/30 backdrop-blur-sm">
+              {children}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.section>
+  )
+}
+
+function CodeBlock({ code, title }: { code: string; title?: string }) {
+  return (
+    <div className="rounded-lg overflow-hidden border border-border/50 my-4">
+      {title && (
+        <div className="px-4 py-2 bg-muted/50 border-b border-border/50 text-xs font-mono text-muted-foreground">
+          {title}
+        </div>
+      )}
+      <pre className="p-4 bg-background/80 overflow-x-auto text-sm font-mono leading-relaxed text-muted-foreground">
+        <code>{code}</code>
+      </pre>
+    </div>
+  )
+}
+
+function DataTable({ headers, rows }: { headers: string[]; rows: string[][] }) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border/50 my-4">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="bg-muted/50">
+            {headers.map((h, i) => (
+              <th key={i} className="px-4 py-3 text-left font-semibold text-foreground border-b border-border/50">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i} className="border-b border-border/30 last:border-0 hover:bg-muted/20 transition-colors">
+              {row.map((cell, j) => (
+                <td key={j} className="px-4 py-3 text-muted-foreground">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function StatCard({ label, value, description }: { label: string; value: string; description: string }) {
+  return (
+    <div className="p-4 rounded-xl bg-primary/5 border border-primary/20 text-center">
+      <div className="text-2xl md:text-3xl font-bold text-primary">{value}</div>
+      <div className="text-sm font-medium text-foreground mt-1">{label}</div>
+      <div className="text-xs text-muted-foreground mt-0.5">{description}</div>
+    </div>
+  )
+}
+
+// ============================================
+// Table of Contents
+// ============================================
+
+const tocSections = [
+  { id: "journey", label: "The Journey", icon: BookOpen },
+  { id: "ecosystem", label: "The Ecosystem", icon: Layers },
+  { id: "agent-prompts", label: "Agent Prompt System", icon: Terminal },
+  { id: "prompt-patterns", label: "10 Prompt Patterns", icon: Code2 },
+  { id: "ai-projects", label: "11 AI Products", icon: Sparkles },
+  { id: "multi-llm", label: "Multi-LLM Strategy", icon: Bot },
+  { id: "voice-first", label: "Voice-First AI", icon: Mic },
+  { id: "privacy-first", label: "Privacy-First", icon: Shield },
+  { id: "cross-machine", label: "Cross-Machine Workflow", icon: Monitor },
+  { id: "quality", label: "Quality Engineering", icon: CheckCircle },
+  { id: "tools", label: "AI Coding Tools", icon: Wrench },
+  { id: "use-cases", label: "Practical Use Cases", icon: Zap },
+  { id: "enterprise", label: "Enterprise Patterns", icon: Server },
+  { id: "lessons", label: "Lessons Learned", icon: Lightbulb },
+]
+
+// ============================================
+// Main Page Component
+// ============================================
+
+export function AIDevelopmentPage() {
+  const [tocOpen, setTocOpen] = useState(false)
+
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="pt-24 pb-20">
+        <div className="container max-w-5xl">
+          {/* Back Button */}
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mb-8">
+            <Button asChild variant="ghost" size="sm">
+              <Link to="/">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back to Portfolio
+              </Link>
+            </Button>
+          </motion.div>
+
+          {/* Page Hero */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="text-center mb-12"
+          >
+            <Badge variant="secondary" className="mb-4 gap-1.5 px-3 py-1">
+              <Brain className="h-3.5 w-3.5" />
+              Comprehensive Deep Dive
+            </Badge>
+            <h1 className="text-4xl md:text-6xl font-bold mb-4 bg-gradient-to-r from-primary via-purple-500 to-pink-500 bg-clip-text text-transparent">
+              AI & LLM Development
+            </h1>
+            <p className="text-lg text-muted-foreground max-w-3xl mx-auto">
+              20+ months of building a production-grade, AI-augmented development pipeline.
+              77+ projects, 11 shipped AI products, 10 reusable prompt patterns,
+              and the complete system behind it all.
+            </p>
+          </motion.div>
+
+          {/* Stats Grid */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.1 }}
+            className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-12"
+          >
+            {aiStats.map((stat) => (
+              <StatCard key={stat.label} {...stat} />
+            ))}
+          </motion.div>
+
+          {/* Table of Contents (collapsible on mobile) */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.2 }}
+            className="mb-12"
+          >
+            <button
+              onClick={() => setTocOpen(!tocOpen)}
+              className="md:hidden w-full flex items-center justify-between p-4 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm"
+            >
+              <span className="font-semibold flex items-center gap-2">
+                <BookOpen className="h-4 w-4 text-primary" />
+                Table of Contents
+              </span>
+              <ChevronDown className={`h-4 w-4 transition-transform ${tocOpen ? "rotate-180" : ""}`} />
+            </button>
+
+            <div className={`${tocOpen ? "block" : "hidden"} md:block`}>
+              <div className="p-4 md:p-6 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm md:mt-0 mt-1">
+                <h3 className="hidden md:block font-semibold mb-3 text-sm uppercase tracking-wider text-muted-foreground">Contents</h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-1">
+                  {tocSections.map((section) => {
+                    const Icon = section.icon
+                    return (
+                      <a
+                        key={section.id}
+                        href={`#${section.id}`}
+                        className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-muted-foreground hover:text-primary hover:bg-primary/5 transition-colors"
+                        onClick={() => setTocOpen(false)}
+                      >
+                        <Icon className="h-3.5 w-3.5" />
+                        {section.label}
+                      </a>
+                    )
+                  })}
+                </div>
+              </div>
+            </div>
+          </motion.div>
+
+          {/* ============================================ */}
+          {/* SECTION: Journey Timeline */}
+          {/* ============================================ */}
+          <CollapsibleSection title="The Journey" icon={BookOpen} id="journey" defaultOpen={true}>
+            <p className="text-muted-foreground mb-8 leading-relaxed">
+              From a Thanksgiving 2019 vision to democratize technology for small businesses,
+              through enterprise client work that forged production patterns,
+              to a complete AI-augmented development ecosystem managing 77+ projects.
+            </p>
+            <div className="relative">
+              <div className="absolute left-4 md:left-6 top-0 bottom-0 w-px bg-border/50" />
+              {journeyTimeline.map((entry, i) => (
+                <div key={i} className="relative pl-12 md:pl-16 pb-8 last:pb-0">
+                  <div className={`absolute left-2 md:left-4 w-4 h-4 rounded-full border-2 ${
+                    entry.milestone
+                      ? "bg-primary border-primary"
+                      : "bg-background border-border"
+                  }`} />
+                  <div className="text-sm font-mono text-primary mb-1">{entry.year}</div>
+                  <h3 className="text-lg font-bold mb-1">{entry.title}</h3>
+                  <p className="text-muted-foreground text-sm leading-relaxed">{entry.description}</p>
+                </div>
+              ))}
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: The Ecosystem */}
+          {/* ============================================ */}
+          <CollapsibleSection title="The 'Apps That Build Apps' Ecosystem" icon={Layers} id="ecosystem" defaultOpen={true}>
+            <p className="text-muted-foreground mb-6 leading-relaxed">{ecosystemDescription}</p>
+
+            <h3 className="text-lg font-bold mb-4">5-Layer Architecture</h3>
+            <div className="space-y-3 mb-8">
+              {ecosystemLayers.map((layer, i) => (
+                <div key={i} className="flex items-start gap-3 p-3 rounded-lg bg-muted/20 border border-border/30">
+                  <Badge variant="outline" className="shrink-0 font-mono text-xs">
+                    {layer.layer}
+                  </Badge>
+                  <div className="flex-1">
+                    <span className="font-semibold">{layer.name}</span>
+                    <span className="text-muted-foreground"> ({layer.tool})</span>
+                    <div className="text-sm text-muted-foreground mt-0.5">{layer.flow}</div>
+                  </div>
+                  {i < ecosystemLayers.length - 1 && (
+                    <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0 mt-1 hidden md:block" />
+                  )}
+                </div>
+              ))}
+            </div>
+
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="p-4 rounded-lg border border-amber-500/30 bg-amber-500/5">
+                <h4 className="font-semibold mb-2">The Quality Triangle</h4>
+                <p className="text-sm text-muted-foreground">{qualityTriangle}</p>
+              </div>
+              <div className="p-4 rounded-lg border border-green-500/30 bg-green-500/5">
+                <h4 className="font-semibold mb-2">Nonprofit Pairing Strategy</h4>
+                <p className="text-sm text-muted-foreground">{nonprofitStrategy}</p>
+              </div>
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Agent Prompt System */}
+          {/* ============================================ */}
+          <CollapsibleSection title="The Agent Prompt System" icon={Terminal} id="agent-prompts">
+            <p className="text-muted-foreground mb-6 leading-relaxed">{agentPromptSystemDescription}</p>
+
+            <h3 className="text-lg font-bold mb-3">Workflow Architecture</h3>
+            <CodeBlock code={agentPromptWorkflow} title="Research → Compile → Build → Develop" />
+
+            <h3 className="text-lg font-bold mb-3 mt-8">4 Meta-Prompts (Prompts That Generate Other Prompts)</h3>
+            <div className="space-y-3 mb-8">
+              {metaPrompts.map((mp, i) => (
+                <div key={i} className="p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="font-mono text-sm font-bold text-primary">{mp.name}</span>
+                    <Badge variant="outline" className="text-xs">{mp.size}</Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{mp.description}</p>
+                </div>
+              ))}
+            </div>
+
+            <h3 className="text-lg font-bold mb-3">Per-Project Structure</h3>
+            <p className="text-sm text-muted-foreground mb-3">
+              Every one of the 77+ projects gets this consistent, version-controlled structure:
+            </p>
+            <CodeBlock code={projectStructure} title="Standard Project Prompt Directory" />
+
+            <div className="mt-6 p-4 rounded-lg border border-purple-500/30 bg-purple-500/5">
+              <h4 className="font-semibold mb-2">Key Innovation: Self-Continuing Research</h4>
+              <p className="text-sm text-muted-foreground">
+                Research prompts include EXECUTION MODE headers forcing agents to execute without asking questions.
+                Each session generates a NEXT SESSION PROMPT for automatic continuation across rate limits and context windows.
+                This eliminates the most common failure mode in multi-session AI work: context loss.
+              </p>
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: 10 Prompt Patterns */}
+          {/* ============================================ */}
+          <CollapsibleSection title="10 Battle-Tested Prompt Patterns" icon={Code2} id="prompt-patterns">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              Extracted from production sessions across save-a-stray, gmail-organizer, and triple-a-lemonade.
+              Each pattern has been refined through real-world use and failure.
+            </p>
+
+            <div className="space-y-4">
+              {promptPatterns.map((pattern) => (
+                <PatternCard key={pattern.id} pattern={pattern} />
+              ))}
+            </div>
+
+            <h3 className="text-lg font-bold mt-10 mb-4">Workflow Combinations</h3>
+            <div className="space-y-4">
+              {workflowCombinations.map((wf, i) => (
+                <div key={i} className="p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <h4 className="font-semibold mb-2">{wf.name}</h4>
+                  <div className="flex flex-wrap items-center gap-1">
+                    {wf.steps.map((step, j) => (
+                      <span key={j} className="flex items-center gap-1">
+                        <Badge variant="secondary" className="text-xs">{step}</Badge>
+                        {j < wf.steps.length - 1 && (
+                          <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                        )}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: 11 AI Products */}
+          {/* ============================================ */}
+          <CollapsibleSection title="11 Production AI Products" icon={Sparkles} id="ai-projects">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              Not experiments or demos. These are shipped, working applications with real users, real test coverage, and real engineering standards.
+            </p>
+
+            <div className="space-y-4">
+              {aiProjects.map((project) => (
+                <AIProjectCard key={project.id} project={project} />
+              ))}
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Multi-LLM Strategy */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Multi-LLM Strategy & Architecture" icon={Bot} id="multi-llm">
+            <h3 className="text-lg font-bold mb-3">Provider Hierarchy</h3>
+            <DataTable
+              headers={["Tier", "Provider", "Models", "Use Case"]}
+              rows={llmProviders.map(p => [p.tier, p.provider, p.models, p.useCase])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Smart Model Routing</h3>
+            <p className="text-sm text-muted-foreground mb-3">
+              Three-tier routing with graceful degradation across 4 fallback levels.
+              If the primary provider fails, the system automatically falls through to the next tier.
+            </p>
+            <DataTable
+              headers={["Tier", "Description", "Models Used"]}
+              rows={modelRoutingTiers.map(t => [t.tier, t.description, t.models])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Token Optimization</h3>
+            <DataTable
+              headers={["Technique", "Result"]}
+              rows={tokenOptimizations.map(t => [t.technique, t.result])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Integration Pipeline</h3>
+            <CodeBlock code={llmPipelineDiagram} title="LLM Integration Architecture" />
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Voice-First AI */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Voice-First AI Development" icon={Mic} id="voice-first">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              A consistent theme across the portfolio: voice as a primary interface.
+              Full duplex conversation at under 500ms latency is a fundamentally different experience from turn-based chat.
+            </p>
+
+            <DataTable
+              headers={["Project", "Technology", "Latency", "Key Feature"]}
+              rows={voiceProjects.map(v => [v.project, v.technology, v.latency, v.keyFeature])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Jarvis Full Duplex Architecture</h3>
+            <CodeBlock code={jarvisArchitectureDiagram} title="Jarvis Voice Assistant Architecture" />
+
+            <h3 className="text-lg font-bold mt-6 mb-3">Three Operating Modes</h3>
+            <DataTable
+              headers={["Mode", "Engine", "Latency", "Description"]}
+              rows={jarvisOperatingModes.map(m => [m.mode, m.engine, m.latency, m.description])}
+            />
+
+            <div className="mt-6 p-4 rounded-lg border border-purple-500/30 bg-purple-500/5">
+              <h4 className="font-semibold mb-2">Full Duplex: What Makes It Different</h4>
+              <p className="text-sm text-muted-foreground">
+                PersonaPlex AI enables simultaneous talking and listening. This means natural interruption support
+                (you can cut in mid-sentence), back-channeling ("mm-hmm", "yeah" while the other is talking),
+                and conversation that feels like talking to another person rather than issuing commands to a machine.
+              </p>
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Privacy-First */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Privacy-First Architecture" icon={Shield} id="privacy-first">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              Where possible, processing stays local. No data leaves the user's device.
+              This is a consistent architectural principle, not a feature toggle.
+            </p>
+
+            <DataTable
+              headers={["Project", "Privacy Approach"]}
+              rows={privacyProjects.map(p => [p.project, p.approach])}
+            />
+
+            <div className="mt-6 p-4 rounded-lg border border-green-500/30 bg-green-500/5">
+              <h4 className="font-semibold flex items-center gap-2 mb-2">
+                <Lock className="h-4 w-4 text-green-400" />
+                BYOK (Bring Your Own Key) Pattern
+              </h4>
+              <p className="text-sm text-muted-foreground">{byokDescription}</p>
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Cross-Machine Workflow */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Cross-Machine Agent Workflow" icon={Monitor} id="cross-machine">
+            <h3 className="text-lg font-bold mb-3">Two-Machine Setup</h3>
+            <DataTable
+              headers={["Machine", "Hardware", "Best For"]}
+              rows={machines.map(m => [m.name, m.hardware, m.bestFor])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">agent-sync Repository</h3>
+            <p className="text-sm text-muted-foreground mb-3">
+              A git-based communication channel between AI agents on different machines.
+              Agents read context at session start, update during work, and push at session end.
+            </p>
+            <DataTable
+              headers={["File", "Purpose"]}
+              rows={agentSyncProtocol.map(a => [a.file, a.purpose])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Sync Protocol</h3>
+            <CodeBlock code={syncWorkflow} title="Multi-Machine Session Workflow" />
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Quality Engineering */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Quality Engineering Standards" icon={CheckCircle} id="quality">
+            <h3 className="text-lg font-bold mb-3">Mandatory Coverage Thresholds</h3>
+            <p className="text-sm text-muted-foreground mb-3">
+              Non-negotiable. CI pipeline blocks merging if any metric falls below threshold.
+            </p>
+            <DataTable
+              headers={["Metric", "Minimum Required"]}
+              rows={qualityMetrics.map(q => [q.metric, q.minimum])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Code Standards</h3>
+            <ul className="space-y-2 mb-8">
+              {codeStandards.map((standard, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <CheckCircle className="h-4 w-4 text-green-400 shrink-0 mt-0.5" />
+                  {standard}
+                </li>
+              ))}
+            </ul>
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Git Workflow</h3>
+            <ul className="space-y-2">
+              {gitWorkflow.map((rule, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <GitBranch className="h-4 w-4 text-blue-400 shrink-0 mt-0.5" />
+                  {rule}
+                </li>
+              ))}
+            </ul>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: AI Coding Tools */}
+          {/* ============================================ */}
+          <CollapsibleSection title="AI Coding Tools & Configuration" icon={Wrench} id="tools">
+            <div className="space-y-4 mb-8">
+              {aiTools.map((tool, i) => (
+                <div key={i} className="p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="font-bold">{tool.name}</span>
+                    <Badge variant="outline" className="text-xs">{tool.stats}</Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{tool.purpose}</p>
+                </div>
+              ))}
+            </div>
+
+            <h3 className="text-lg font-bold mb-3">Claude Code Configuration</h3>
+            <CodeBlock code={claudeCodeConfig} title="Configuration Infrastructure" />
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Practical Use Cases */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Practical Day-to-Day Use Cases" icon={Zap} id="use-cases">
+            <div className="space-y-6">
+              {useCases.map((uc) => (
+                <div key={uc.id} className="p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <h4 className="font-bold mb-2">{uc.title}</h4>
+                  <p className="text-sm text-muted-foreground mb-3">{uc.description}</p>
+                  {uc.codeSnippet && (
+                    <CodeBlock code={uc.codeSnippet} />
+                  )}
+                </div>
+              ))}
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Enterprise Patterns */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Enterprise Patterns from Production" icon={Server} id="enterprise">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              Patterns extracted from enterprise client work at Tailored Technologies (2021-2023)
+              and refined across the portfolio ecosystem.
+            </p>
+
+            <div className="space-y-6 mb-8">
+              {enterprisePatterns.map((pattern, i) => (
+                <div key={i} className="p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <h4 className="font-bold mb-2">{pattern.title}</h4>
+                  <p className="text-sm text-muted-foreground mb-3">{pattern.description}</p>
+                  <ul className="space-y-1.5">
+                    {pattern.details.map((detail, j) => (
+                      <li key={j} className="flex items-start gap-2 text-sm text-muted-foreground">
+                        <ChevronRight className="h-3.5 w-3.5 text-primary shrink-0 mt-0.5" />
+                        {detail}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+
+            <h3 className="text-lg font-bold mb-3">Advanced Prompt Engineering Patterns</h3>
+            <div className="grid md:grid-cols-2 gap-3">
+              {advancedPatterns.map((pattern, i) => (
+                <div key={i} className="p-3 rounded-lg border border-border/30 bg-muted/10">
+                  <h5 className="font-semibold text-sm mb-1">{pattern.name}</h5>
+                  <p className="text-xs text-muted-foreground">{pattern.description}</p>
+                </div>
+              ))}
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Lessons Learned */}
+          {/* ============================================ */}
+          <CollapsibleSection title="10 Lessons Learned" icon={Lightbulb} id="lessons" defaultOpen={true}>
+            <div className="space-y-4">
+              {lessonsLearned.map((lesson) => (
+                <div key={lesson.number} className="p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <div className="flex items-start gap-3">
+                    <div className="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center text-sm font-bold shrink-0">
+                      {lesson.number}
+                    </div>
+                    <div>
+                      <h4 className="font-bold mb-1">{lesson.title}</h4>
+                      <p className="text-sm text-muted-foreground leading-relaxed">{lesson.insight}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CollapsibleSection>
+
+          {/* Back to Portfolio */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}
+            className="flex justify-center mt-16"
+          >
+            <Button asChild variant="outline" size="lg">
+              <Link to="/">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back to Portfolio
+              </Link>
+            </Button>
+          </motion.div>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+// ============================================
+// Sub-Components for Complex Sections
+// ============================================
+
+function PatternCard({ pattern }: { pattern: typeof promptPatterns[number] }) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-muted/10 overflow-hidden">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full p-4 flex items-start gap-3 text-left hover:bg-muted/20 transition-colors"
+      >
+        <div className="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center text-sm font-bold shrink-0">
+          {pattern.number}
+        </div>
+        <div className="flex-1">
+          <h4 className="font-bold">{pattern.name}</h4>
+          <p className="text-xs text-muted-foreground mt-0.5">Source: {pattern.source}</p>
+        </div>
+        <ChevronDown className={`h-4 w-4 text-muted-foreground shrink-0 mt-1 transition-transform ${expanded ? "rotate-180" : ""}`} />
+      </button>
+
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="px-4 pb-4 space-y-3 border-t border-border/30 pt-3">
+              <div>
+                <span className="text-xs font-semibold uppercase tracking-wider text-red-400">Problem</span>
+                <p className="text-sm text-muted-foreground mt-1">{pattern.problem}</p>
+              </div>
+              <div>
+                <span className="text-xs font-semibold uppercase tracking-wider text-green-400">Solution</span>
+                <p className="text-sm text-muted-foreground mt-1">{pattern.solution}</p>
+              </div>
+              <div className="p-3 rounded-lg bg-primary/5 border border-primary/20">
+                <span className="text-xs font-semibold uppercase tracking-wider text-primary">Key Insight</span>
+                <p className="text-sm text-muted-foreground mt-1">{pattern.keyInsight}</p>
+              </div>
+              {pattern.template && (
+                <CodeBlock code={pattern.template} title="Prompt Template" />
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}
+
+function AIProjectCard({ project }: { project: typeof aiProjects[number] }) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-muted/10 overflow-hidden">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full p-4 flex items-start gap-3 text-left hover:bg-muted/20 transition-colors"
+      >
+        <div className="p-2 rounded-lg bg-primary/10 text-primary shrink-0">
+          <Sparkles className="h-4 w-4" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h4 className="font-bold">{project.name}</h4>
+            <Badge variant="outline" className="text-xs">{project.status}</Badge>
+          </div>
+          <p className="text-sm text-muted-foreground mt-0.5">{project.purpose}</p>
+        </div>
+        <ChevronDown className={`h-4 w-4 text-muted-foreground shrink-0 mt-1 transition-transform ${expanded ? "rotate-180" : ""}`} />
+      </button>
+
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="px-4 pb-4 space-y-3 border-t border-border/30 pt-3">
+              <div className="p-3 rounded-lg bg-primary/5 border border-primary/20">
+                <span className="text-xs font-semibold uppercase tracking-wider text-primary">Core Innovation</span>
+                <p className="text-sm text-muted-foreground mt-1">{project.innovation}</p>
+              </div>
+              <div>
+                <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">AI Features</span>
+                <ul className="mt-1 space-y-1">
+                  {project.aiFeatures.map((feature, i) => (
+                    <li key={i} className="flex items-start gap-2 text-sm text-muted-foreground">
+                      <Zap className="h-3.5 w-3.5 text-yellow-400 shrink-0 mt-0.5" />
+                      {feature}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {project.stack.map((tech, i) => (
+                  <Badge key={i} variant="secondary" className="text-xs">{tech}</Badge>
+                ))}
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/src/pages/AIDevelopmentPage.tsx
+++ b/src/pages/AIDevelopmentPage.tsx
@@ -8,6 +8,7 @@ import {
   Server, RotateCw, TrendingUp, Users, Ban, Briefcase,
   FileText, HardDrive, Gauge, Smartphone, Share2,
   AlertTriangle, DollarSign, Video,
+  TestTube2, Workflow, Package, Database, FolderTree, BarChart3,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -76,6 +77,29 @@ import {
   enforcementGapsDescription,
   additionalFindings,
   tutorialRecordingsDescription,
+  testingInfraStats,
+  testDistribution,
+  topTestedProjects,
+  testFrameworks,
+  testingBlindSpot,
+  cicdStats,
+  cicdTiers,
+  cicdZeroAISteps,
+  dependencyScale,
+  aiPackages,
+  uiLibraryUsage,
+  proprietaryPackages,
+  deepestAIStack,
+  infraScale,
+  databaseUsage,
+  apiFrameworks,
+  sddCoverageDetails,
+  sddStats,
+  promptInfraScale,
+  largestCompiledResearch,
+  templateConsistencyDescription,
+  portfolioMaturitySpectrum,
+  enterpriseOutlier,
 } from "@/data/ai-development"
 
 // ============================================
@@ -221,6 +245,12 @@ const tocSections = [
   { id: "native-apps", label: "Native macOS Apps", icon: Smartphone },
   { id: "spectree-exports", label: "SpecTree Exports", icon: FileText },
   { id: "cost-optimization", label: "Cost Optimization", icon: DollarSign },
+  { id: "testing-infra", label: "Testing Infrastructure", icon: TestTube2 },
+  { id: "cicd-patterns", label: "CI/CD Patterns", icon: Workflow },
+  { id: "dependencies", label: "Dependency Ecosystem", icon: Package },
+  { id: "infra-deploy", label: "Infrastructure", icon: Database },
+  { id: "sdd-coverage", label: "SDD Coverage", icon: FolderTree },
+  { id: "prompt-infra", label: "Prompt Infrastructure", icon: BarChart3 },
   { id: "enforcement-gaps", label: "Enforcement Gaps", icon: AlertTriangle },
   { id: "use-cases", label: "Practical Use Cases", icon: Zap },
   { id: "enterprise", label: "Enterprise Patterns", icon: Server },
@@ -950,6 +980,217 @@ export function AIDevelopmentPage() {
               headers={["Technique", "Result", "Project"]}
               rows={costOptimizationPatterns.map(c => [c.technique, c.result, c.project])}
             />
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Testing Infrastructure */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Testing Infrastructure (559K Lines)" icon={TestTube2} id="testing-infra">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              2,918 test files with 559,535 lines of test code across 30+ projects.
+              Strong commitment to testing, with a notable blind spot in AI/LLM output validation.
+            </p>
+
+            <h3 className="text-lg font-bold mb-3">Testing Scale</h3>
+            <DataTable
+              headers={["Metric", "Value"]}
+              rows={testingInfraStats.map(s => [s.metric, s.value])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Distribution by Language</h3>
+            <DataTable
+              headers={["Language", "Files", "Percentage"]}
+              rows={testDistribution.map(d => [d.language, d.files, d.percentage])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Top Projects by Test Coverage</h3>
+            <DataTable
+              headers={["Project", "Test Files", "Lines", "Framework"]}
+              rows={topTestedProjects.map(p => [p.project, p.testFiles, p.lines, p.framework])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Testing Frameworks</h3>
+            <DataTable
+              headers={["Framework", "Projects", "Purpose"]}
+              rows={testFrameworks.map(f => [f.name, f.projects, f.purpose])}
+            />
+
+            <div className="mt-6 p-4 rounded-lg border border-amber-500/30 bg-amber-500/5">
+              <h4 className="font-semibold mb-2">AI Testing Blind Spot</h4>
+              <p className="text-sm text-muted-foreground">{testingBlindSpot}</p>
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: CI/CD Patterns */}
+          {/* ============================================ */}
+          <CollapsibleSection title="CI/CD Workflow Patterns (45 Workflows)" icon={Workflow} id="cicd-patterns">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              45 GitHub Actions workflows across 46 repos with 91% CodeRabbit adoption and 89% Dependabot adoption.
+              Template-driven consistency proves the prompt system produces reliable infrastructure.
+            </p>
+
+            <h3 className="text-lg font-bold mb-3">CI/CD Scale</h3>
+            <DataTable
+              headers={["Metric", "Value"]}
+              rows={cicdStats.map(s => [s.metric, s.value])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Pipeline Sophistication Tiers</h3>
+            <div className="space-y-3">
+              {cicdTiers.map((tier, i) => (
+                <div key={i} className="p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="font-bold">{tier.tier}</span>
+                    <Badge variant="outline" className="text-xs">{tier.repos} repos ({tier.percentage})</Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{tier.description}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-6 p-4 rounded-lg border border-red-500/30 bg-red-500/5">
+              <h4 className="font-semibold mb-2">Zero AI-Specific CI Steps</h4>
+              <p className="text-sm text-muted-foreground">{cicdZeroAISteps}</p>
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Dependency Ecosystem */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Dependency Ecosystem (14 AI Packages)" icon={Package} id="dependencies">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              74 Node.js packages, 18 Python packages, and 14 distinct AI/LLM packages across 18 projects (33% of the portfolio).
+              Three proprietary LLM integration packages built in-house.
+            </p>
+
+            <h3 className="text-lg font-bold mb-3">Package Scale</h3>
+            <DataTable
+              headers={["Category", "Count"]}
+              rows={dependencyScale.map(d => [d.category, d.count])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">AI/LLM Package Usage</h3>
+            <DataTable
+              headers={["Package", "Projects Using", "Version"]}
+              rows={aiPackages.map(p => [p.name, p.projectsUsing, p.version])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Proprietary LLM Packages</h3>
+            <div className="space-y-3">
+              {proprietaryPackages.map((pkg, i) => (
+                <div key={i} className="p-3 rounded-lg border border-border/30 bg-muted/10">
+                  <span className="font-mono text-sm font-semibold text-primary">{pkg.name}</span>
+                  <span className="text-sm text-muted-foreground"> ({pkg.project})</span>
+                  <p className="text-xs text-muted-foreground mt-1">{pkg.purpose}</p>
+                </div>
+              ))}
+            </div>
+
+            <h3 className="text-lg font-bold mt-8 mb-3">UI Component Standardization</h3>
+            <DataTable
+              headers={["Library", "Projects Using"]}
+              rows={uiLibraryUsage.map(u => [u.library, u.projects])}
+            />
+
+            <div className="mt-6 p-4 rounded-lg border border-blue-500/30 bg-blue-500/5">
+              <h4 className="font-semibold mb-2">Deepest AI Stack: Research Agent</h4>
+              <p className="text-sm text-muted-foreground">{deepestAIStack}</p>
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Infrastructure & Deployment */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Infrastructure & Deployment (984 API Routes)" icon={Database} id="infra-deploy">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              78 Dockerfiles, 65 docker-compose files, 49 Render configs, 984 API route files,
+              6 database technologies, and 5 API frameworks. The infrastructure layer that supports the AI ecosystem.
+            </p>
+
+            <h3 className="text-lg font-bold mb-3">Infrastructure Scale</h3>
+            <DataTable
+              headers={["Resource", "Count"]}
+              rows={infraScale.map(r => [r.resource, r.count])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Database Strategy (6 Technologies)</h3>
+            <DataTable
+              headers={["Database", "Projects", "Use Case"]}
+              rows={databaseUsage.map(d => [d.database, d.projects, d.useCase])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">API Frameworks (5 Frameworks)</h3>
+            <DataTable
+              headers={["Framework", "Projects", "Use Case"]}
+              rows={apiFrameworks.map(f => [f.framework, f.projects, f.useCase])}
+            />
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: SDD Coverage */}
+          {/* ============================================ */}
+          <CollapsibleSection title="SDD Coverage (77 Documents, 24 Projects)" icon={FolderTree} id="sdd-coverage">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              77 Software Design Documents across 24 projects with dedicated sdd/ directories.
+              37 ARCHITECTURE.md files and 47 ROADMAP.md files provide additional structural documentation.
+              Two naming conventions emerged: sequential (SDD-001) and feature-based (F1.1).
+            </p>
+
+            <h3 className="text-lg font-bold mb-3">SDD Stats</h3>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
+              {Object.entries(sddStats).map(([key, value]) => (
+                <div key={key} className="p-3 rounded-lg bg-muted/20 border border-border/30 text-center">
+                  <div className="text-sm font-bold text-foreground">{value}</div>
+                  <div className="text-xs text-muted-foreground capitalize">{key.replace(/([A-Z])/g, " $1").trim()}</div>
+                </div>
+              ))}
+            </div>
+
+            <h3 className="text-lg font-bold mb-3">Most Comprehensive SDD Coverage</h3>
+            <DataTable
+              headers={["Project", "SDD Files", "Phases Covered"]}
+              rows={sddCoverageDetails.map(s => [s.project, s.sddFiles, s.phases])}
+            />
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Prompt Infrastructure Scale */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Prompt Infrastructure Scale (317 Files, 7.86 MB)" icon={BarChart3} id="prompt-infra">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              {templateConsistencyDescription}
+            </p>
+
+            <h3 className="text-lg font-bold mb-3">Prompt File Metrics</h3>
+            <DataTable
+              headers={["Resource", "Count", "Total Size"]}
+              rows={promptInfraScale.map(p => [p.resource, p.count, p.totalSize])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Largest Compiled Research</h3>
+            <DataTable
+              headers={["Project", "Lines", "Size"]}
+              rows={largestCompiledResearch.map(r => [r.project, r.lines, r.size])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Portfolio Maturity Spectrum</h3>
+            <div className="space-y-3">
+              {portfolioMaturitySpectrum.map((tier, i) => (
+                <div key={i} className="p-3 rounded-lg border border-border/30 bg-muted/10">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="font-bold text-sm">{tier.tier}</span>
+                    <Badge variant="outline" className="text-xs">{tier.percentage}</Badge>
+                  </div>
+                  <p className="text-xs text-muted-foreground">{tier.description}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-6 p-4 rounded-lg border border-purple-500/30 bg-purple-500/5">
+              <h4 className="font-semibold mb-2">Enterprise Outlier</h4>
+              <p className="text-sm text-muted-foreground">{enterpriseOutlier}</p>
+            </div>
           </CollapsibleSection>
 
           {/* ============================================ */}

--- a/src/pages/AIDevelopmentPage.tsx
+++ b/src/pages/AIDevelopmentPage.tsx
@@ -5,7 +5,8 @@ import {
   ArrowLeft, Brain, Bot, Shield, Mic, Terminal, Layers, Sparkles,
   ChevronDown, ChevronRight, Code2, Zap, BookOpen, Wrench,
   GitBranch, CheckCircle, Monitor, Lightbulb, ArrowRight, Lock,
-  Server,
+  Server, RotateCw, TrendingUp, Users, Ban, Briefcase,
+  FileText, HardDrive,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -44,6 +45,21 @@ import {
   enterprisePatterns,
   advancedPatterns,
   lessonsLearned,
+  forbiddenPatterns,
+  forbiddenPatternsDescription,
+  developmentLifecycle,
+  multiAgentSystem,
+  multiAgentWorkSlots,
+  marketResearchReports,
+  careerTimeline,
+  sddFirstDescription,
+  sddTriggers,
+  sddNoPLaceholders,
+  qualityChecklists,
+  documentHierarchy,
+  googleDriveStats,
+  toolDiversificationStrategy,
+  crossAgentVerification,
 } from "@/data/ai-development"
 
 // ============================================
@@ -168,15 +184,21 @@ function StatCard({ label, value, description }: { label: string; value: string;
 
 const tocSections = [
   { id: "journey", label: "The Journey", icon: BookOpen },
+  { id: "career", label: "Career Context", icon: Briefcase },
   { id: "ecosystem", label: "The Ecosystem", icon: Layers },
   { id: "agent-prompts", label: "Agent Prompt System", icon: Terminal },
+  { id: "lifecycle", label: "Development Lifecycle", icon: RotateCw },
   { id: "prompt-patterns", label: "10 Prompt Patterns", icon: Code2 },
   { id: "ai-projects", label: "11 AI Products", icon: Sparkles },
+  { id: "market-research", label: "Market Research", icon: TrendingUp },
   { id: "multi-llm", label: "Multi-LLM Strategy", icon: Bot },
   { id: "voice-first", label: "Voice-First AI", icon: Mic },
   { id: "privacy-first", label: "Privacy-First", icon: Shield },
   { id: "cross-machine", label: "Cross-Machine Workflow", icon: Monitor },
+  { id: "multi-agent", label: "Multi-Agent Orchestration", icon: Users },
   { id: "quality", label: "Quality Engineering", icon: CheckCircle },
+  { id: "forbidden", label: "Forbidden Patterns", icon: Ban },
+  { id: "doc-hierarchy", label: "Document Hierarchy", icon: FileText },
   { id: "tools", label: "AI Coding Tools", icon: Wrench },
   { id: "use-cases", label: "Practical Use Cases", icon: Zap },
   { id: "enterprise", label: "Enterprise Patterns", icon: Server },
@@ -304,6 +326,38 @@ export function AIDevelopmentPage() {
           </CollapsibleSection>
 
           {/* ============================================ */}
+          {/* SECTION: Career Context */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Career Context" icon={Briefcase} id="career">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              The AI development expertise didn't emerge in isolation. It was built on a foundation of
+              entrepreneurship, enterprise engineering, and production-pressure client work.
+            </p>
+
+            <div className="space-y-4">
+              {careerTimeline.map((entry, i) => (
+                <div key={i} className="p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <div className="flex items-center gap-3 mb-2">
+                    <Badge variant="outline" className="font-mono text-xs shrink-0">{entry.period}</Badge>
+                    <div>
+                      <span className="font-bold">{entry.role}</span>
+                      <span className="text-muted-foreground"> at {entry.company}</span>
+                    </div>
+                  </div>
+                  <ul className="space-y-1 ml-1">
+                    {entry.highlights.map((highlight, j) => (
+                      <li key={j} className="flex items-start gap-2 text-sm text-muted-foreground">
+                        <ChevronRight className="h-3.5 w-3.5 text-primary shrink-0 mt-0.5" />
+                        {highlight}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
           {/* SECTION: The Ecosystem */}
           {/* ============================================ */}
           <CollapsibleSection title="The 'Apps That Build Apps' Ecosystem" icon={Layers} id="ecosystem" defaultOpen={true}>
@@ -379,6 +433,37 @@ export function AIDevelopmentPage() {
           </CollapsibleSection>
 
           {/* ============================================ */}
+          {/* SECTION: 8-Step Development Lifecycle */}
+          {/* ============================================ */}
+          <CollapsibleSection title="8-Step Development Lifecycle" icon={RotateCw} id="lifecycle">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              Every project follows this standardized pipeline from idea to deployment.
+              Each step has a dedicated tool, a defined output, and a clear handoff to the next step.
+            </p>
+
+            <div className="space-y-3">
+              {developmentLifecycle.map((step, i) => (
+                <div key={i} className="flex items-start gap-4 p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <div className="w-10 h-10 rounded-full bg-primary/10 text-primary flex items-center justify-center text-sm font-bold shrink-0">
+                    {step.step}
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 flex-wrap mb-1">
+                      <span className="font-bold">{step.name}</span>
+                      <Badge variant="outline" className="text-xs">{step.tool}</Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground">{step.description}</p>
+                    <div className="text-xs text-muted-foreground/70 mt-1 font-mono">Output: {step.output}</div>
+                  </div>
+                  {i < developmentLifecycle.length - 1 && (
+                    <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0 mt-3 hidden md:block" />
+                  )}
+                </div>
+              ))}
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
           {/* SECTION: 10 Prompt Patterns */}
           {/* ============================================ */}
           <CollapsibleSection title="10 Battle-Tested Prompt Patterns" icon={Code2} id="prompt-patterns">
@@ -424,6 +509,41 @@ export function AIDevelopmentPage() {
             <div className="space-y-4">
               {aiProjects.map((project) => (
                 <AIProjectCard key={project.id} project={project} />
+              ))}
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Market Research & Validation */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Market Research & Validation" icon={TrendingUp} id="market-research">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              11 full competitive intelligence reports with validated unit economics, pricing models,
+              and market gap analysis. Each project is backed by real research, not assumptions.
+            </p>
+
+            <div className="space-y-3">
+              {marketResearchReports.map((report, i) => (
+                <div key={i} className="p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <div className="flex items-center gap-2 mb-2 flex-wrap">
+                    <span className="font-bold">{report.project}</span>
+                    <Badge variant="outline" className="text-xs">{report.market}</Badge>
+                  </div>
+                  <div className="grid md:grid-cols-3 gap-3 text-sm">
+                    <div>
+                      <span className="text-xs font-semibold uppercase tracking-wider text-primary">Key Insight</span>
+                      <p className="text-muted-foreground mt-0.5">{report.keyInsight}</p>
+                    </div>
+                    <div>
+                      <span className="text-xs font-semibold uppercase tracking-wider text-green-400">Pricing</span>
+                      <p className="text-muted-foreground mt-0.5">{report.pricing}</p>
+                    </div>
+                    <div>
+                      <span className="text-xs font-semibold uppercase tracking-wider text-amber-400">Differentiator</span>
+                      <p className="text-muted-foreground mt-0.5">{report.differentiator}</p>
+                    </div>
+                  </div>
+                </div>
               ))}
             </div>
           </CollapsibleSection>
@@ -539,6 +659,24 @@ export function AIDevelopmentPage() {
           </CollapsibleSection>
 
           {/* ============================================ */}
+          {/* SECTION: Multi-Agent Orchestration */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Multi-Agent Orchestration" icon={Users} id="multi-agent">
+            <p className="text-muted-foreground mb-6 leading-relaxed whitespace-pre-line">{multiAgentSystem}</p>
+
+            <h3 className="text-lg font-bold mb-3">4 Concurrent Work Slots</h3>
+            <DataTable
+              headers={["Slot", "Status", "Description"]}
+              rows={multiAgentWorkSlots.map(s => [s.slot, s.status, s.description])}
+            />
+
+            <div className="mt-6 p-4 rounded-lg border border-blue-500/30 bg-blue-500/5">
+              <h4 className="font-semibold mb-2">Cross-Agent Verification</h4>
+              <p className="text-sm text-muted-foreground">{crossAgentVerification}</p>
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
           {/* SECTION: Quality Engineering */}
           {/* ============================================ */}
           <CollapsibleSection title="Quality Engineering Standards" icon={CheckCircle} id="quality">
@@ -562,7 +700,7 @@ export function AIDevelopmentPage() {
             </ul>
 
             <h3 className="text-lg font-bold mt-8 mb-3">Git Workflow</h3>
-            <ul className="space-y-2">
+            <ul className="space-y-2 mb-8">
               {gitWorkflow.map((rule, i) => (
                 <li key={i} className="flex items-start gap-2 text-sm text-muted-foreground">
                   <GitBranch className="h-4 w-4 text-blue-400 shrink-0 mt-0.5" />
@@ -570,6 +708,97 @@ export function AIDevelopmentPage() {
                 </li>
               ))}
             </ul>
+
+            <h3 className="text-lg font-bold mt-8 mb-3">6 Quality Checklists</h3>
+            <div className="grid md:grid-cols-2 gap-3">
+              {qualityChecklists.map((checklist, i) => (
+                <div key={i} className="p-3 rounded-lg border border-border/30 bg-muted/10">
+                  <span className="font-mono text-sm font-bold text-primary">{checklist.name}</span>
+                  <p className="text-xs text-muted-foreground mt-1">{checklist.purpose}</p>
+                </div>
+              ))}
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Forbidden Patterns */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Forbidden Patterns & Zero-Tolerance Standards" icon={Ban} id="forbidden">
+            <p className="text-muted-foreground mb-6 leading-relaxed">{forbiddenPatternsDescription}</p>
+
+            <div className="space-y-4">
+              {forbiddenPatterns.map((fp, i) => (
+                <div key={i} className="p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="font-bold">{fp.category}</span>
+                    <Badge
+                      variant="outline"
+                      className={`text-xs ${
+                        fp.severity === "CRITICAL" ? "border-red-500/50 text-red-400" :
+                        fp.severity === "HIGH" ? "border-orange-500/50 text-orange-400" :
+                        "border-yellow-500/50 text-yellow-400"
+                      }`}
+                    >
+                      {fp.severity}
+                    </Badge>
+                  </div>
+                  <div className="flex flex-wrap gap-1.5 mb-2">
+                    {fp.patterns.map((pattern, j) => (
+                      <code key={j} className="text-xs px-2 py-0.5 rounded bg-red-500/10 text-red-300 font-mono">{pattern}</code>
+                    ))}
+                  </div>
+                  <div className="text-xs text-muted-foreground font-mono">Detection: {fp.detection}</div>
+                </div>
+              ))}
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Document Hierarchy */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Document Hierarchy & Configuration" icon={FileText} id="doc-hierarchy">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              A 7-layer documentation system ensures consistent rules, from global standards
+              down to per-project specifics. Higher layers override lower ones.
+            </p>
+
+            <div className="space-y-3 mb-8">
+              {documentHierarchy.map((doc, i) => (
+                <div key={i} className="flex items-start gap-3 p-3 rounded-lg bg-muted/20 border border-border/30">
+                  <Badge variant="outline" className="shrink-0 font-mono text-xs">L{doc.level}</Badge>
+                  <div>
+                    <span className="font-mono text-sm font-semibold">{doc.name}</span>
+                    <p className="text-sm text-muted-foreground mt-0.5">{doc.description}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <h3 className="text-lg font-bold mb-3">SDD-First Development</h3>
+            <p className="text-muted-foreground mb-4 text-sm">{sddFirstDescription}</p>
+            <div className="grid md:grid-cols-2 gap-3 mb-4">
+              {sddTriggers.map((trigger, i) => (
+                <div key={i} className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <ChevronRight className="h-3.5 w-3.5 text-primary shrink-0 mt-0.5" />
+                  {trigger}
+                </div>
+              ))}
+            </div>
+            <div className="p-4 rounded-lg border border-red-500/30 bg-red-500/5">
+              <h4 className="font-semibold text-sm mb-1">No Placeholders Allowed</h4>
+              <p className="text-xs text-muted-foreground">{sddNoPLaceholders}</p>
+            </div>
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Google Drive Archive</h3>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+              {Object.entries(googleDriveStats).map(([key, value]) => (
+                <div key={key} className="p-3 rounded-lg bg-muted/20 border border-border/30 text-center">
+                  <HardDrive className="h-4 w-4 text-muted-foreground mx-auto mb-1" />
+                  <div className="text-sm font-bold text-foreground">{value}</div>
+                  <div className="text-xs text-muted-foreground capitalize">{key.replace(/([A-Z])/g, " $1").trim()}</div>
+                </div>
+              ))}
+            </div>
           </CollapsibleSection>
 
           {/* ============================================ */}
@@ -587,6 +816,9 @@ export function AIDevelopmentPage() {
                 </div>
               ))}
             </div>
+
+            <h3 className="text-lg font-bold mb-3">Tool Diversification Strategy</h3>
+            <p className="text-sm text-muted-foreground mb-4 whitespace-pre-line">{toolDiversificationStrategy}</p>
 
             <h3 className="text-lg font-bold mb-3">Claude Code Configuration</h3>
             <CodeBlock code={claudeCodeConfig} title="Configuration Infrastructure" />
@@ -635,7 +867,7 @@ export function AIDevelopmentPage() {
               ))}
             </div>
 
-            <h3 className="text-lg font-bold mb-3">Advanced Prompt Engineering Patterns</h3>
+            <h3 className="text-lg font-bold mt-8 mb-3">Advanced Prompt Engineering Patterns</h3>
             <div className="grid md:grid-cols-2 gap-3">
               {advancedPatterns.map((pattern, i) => (
                 <div key={i} className="p-3 rounded-lg border border-border/30 bg-muted/10">

--- a/src/pages/AIDevelopmentPage.tsx
+++ b/src/pages/AIDevelopmentPage.tsx
@@ -6,7 +6,8 @@ import {
   ChevronDown, ChevronRight, Code2, Zap, BookOpen, Wrench,
   GitBranch, CheckCircle, Monitor, Lightbulb, ArrowRight, Lock,
   Server, RotateCw, TrendingUp, Users, Ban, Briefcase,
-  FileText, HardDrive,
+  FileText, HardDrive, Gauge, Smartphone, Share2,
+  AlertTriangle, DollarSign, Video,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -60,6 +61,21 @@ import {
   googleDriveStats,
   toolDiversificationStrategy,
   crossAgentVerification,
+  developmentAcceleration,
+  accelerationDescription,
+  claudeCodeDetailedStats,
+  specTreeExportFormats,
+  nativeMacOSApps,
+  nativeMacAppPattern,
+  personaplexProjects,
+  personaplexDescription,
+  costOptimizationPatterns,
+  crossToolSyncDescription,
+  crossToolSyncEvidence,
+  enforcementGaps,
+  enforcementGapsDescription,
+  additionalFindings,
+  tutorialRecordingsDescription,
 } from "@/data/ai-development"
 
 // ============================================
@@ -199,7 +215,13 @@ const tocSections = [
   { id: "quality", label: "Quality Engineering", icon: CheckCircle },
   { id: "forbidden", label: "Forbidden Patterns", icon: Ban },
   { id: "doc-hierarchy", label: "Document Hierarchy", icon: FileText },
+  { id: "acceleration", label: "58x Acceleration", icon: Gauge },
   { id: "tools", label: "AI Coding Tools", icon: Wrench },
+  { id: "cross-tool-sync", label: "Cross-Tool Sync", icon: Share2 },
+  { id: "native-apps", label: "Native macOS Apps", icon: Smartphone },
+  { id: "spectree-exports", label: "SpecTree Exports", icon: FileText },
+  { id: "cost-optimization", label: "Cost Optimization", icon: DollarSign },
+  { id: "enforcement-gaps", label: "Enforcement Gaps", icon: AlertTriangle },
   { id: "use-cases", label: "Practical Use Cases", icon: Zap },
   { id: "enterprise", label: "Enterprise Patterns", icon: Server },
   { id: "lessons", label: "Lessons Learned", icon: Lightbulb },
@@ -802,6 +824,33 @@ export function AIDevelopmentPage() {
           </CollapsibleSection>
 
           {/* ============================================ */}
+          {/* SECTION: 58x Development Acceleration */}
+          {/* ============================================ */}
+          <CollapsibleSection title="58x Development Acceleration" icon={Gauge} id="acceleration">
+            <p className="text-muted-foreground mb-6 leading-relaxed">{accelerationDescription}</p>
+
+            <DataTable
+              headers={["Period", "Commits/Year", "Repos Created", "Note"]}
+              rows={developmentAcceleration.map(a => [a.period, a.commitsPerYear, a.reposCreated, a.note])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Claude Code Session Statistics</h3>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+              {Object.entries(claudeCodeDetailedStats).map(([key, value]) => (
+                <div key={key} className="p-3 rounded-lg bg-muted/20 border border-border/30 text-center">
+                  <div className="text-sm font-bold text-foreground">{value}</div>
+                  <div className="text-xs text-muted-foreground capitalize">{key.replace(/([A-Z])/g, " $1").trim()}</div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-6 p-4 rounded-lg border border-amber-500/30 bg-amber-500/5">
+              <h4 className="font-semibold mb-2">Video Evidence</h4>
+              <p className="text-sm text-muted-foreground">{tutorialRecordingsDescription}</p>
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
           {/* SECTION: AI Coding Tools */}
           {/* ============================================ */}
           <CollapsibleSection title="AI Coding Tools & Configuration" icon={Wrench} id="tools">
@@ -822,6 +871,107 @@ export function AIDevelopmentPage() {
 
             <h3 className="text-lg font-bold mb-3">Claude Code Configuration</h3>
             <CodeBlock code={claudeCodeConfig} title="Configuration Infrastructure" />
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Cross-Tool Instruction Sync */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Cross-Tool Instruction Synchronization" icon={Share2} id="cross-tool-sync">
+            <p className="text-muted-foreground mb-6 leading-relaxed">{crossToolSyncDescription}</p>
+
+            <div className="space-y-3">
+              {crossToolSyncEvidence.map((evidence, i) => (
+                <div key={i} className="p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="font-bold">{evidence.tool}</span>
+                    <Badge variant="outline" className="text-xs">{evidence.method}</Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground italic">"{evidence.quote}"</p>
+                </div>
+              ))}
+            </div>
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Native macOS Apps */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Native macOS Menu Bar Apps" icon={Smartphone} id="native-apps">
+            <p className="text-muted-foreground mb-6 leading-relaxed">{nativeMacAppPattern}</p>
+
+            <div className="space-y-4">
+              {nativeMacOSApps.map((app, i) => (
+                <div key={i} className="p-4 rounded-lg border border-border/50 bg-muted/10">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="font-bold">{app.name}</span>
+                  </div>
+                  <p className="text-sm text-muted-foreground mb-2">{app.purpose}</p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {app.features.map((feature, j) => (
+                      <Badge key={j} variant="secondary" className="text-xs">{feature}</Badge>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <h3 className="text-lg font-bold mt-8 mb-3">PersonaPlex Cross-Project Voice Strategy</h3>
+            <p className="text-sm text-muted-foreground mb-4">{personaplexDescription}</p>
+            <DataTable
+              headers={["Project", "Voice Use Case"]}
+              rows={personaplexProjects.map(p => [p.project, p.voiceUseCase])}
+            />
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: SpecTree Export Formats */}
+          {/* ============================================ */}
+          <CollapsibleSection title="SpecTree AI Tool Exports (9 Formats)" icon={FileText} id="spectree-exports">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              SpecTree (Blueprint Builder) exports structured specifications to 9 different AI tool formats,
+              making it a universal specification-to-agent bridge. Write your spec once, export to any AI coding tool.
+            </p>
+
+            <DataTable
+              headers={["AI Tool", "Format", "Description"]}
+              rows={specTreeExportFormats.map(f => [f.name, f.format, f.description])}
+            />
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Cost Optimization */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Cost Optimization Patterns" icon={DollarSign} id="cost-optimization">
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              Running 58 projects with AI agents requires systematic cost management.
+              These patterns reduce AI API costs by 96-97% compared to naive implementation.
+            </p>
+
+            <DataTable
+              headers={["Technique", "Result", "Project"]}
+              rows={costOptimizationPatterns.map(c => [c.technique, c.result, c.project])}
+            />
+          </CollapsibleSection>
+
+          {/* ============================================ */}
+          {/* SECTION: Enforcement Gaps */}
+          {/* ============================================ */}
+          <CollapsibleSection title="Enforcement Gaps (Honest Self-Assessment)" icon={AlertTriangle} id="enforcement-gaps">
+            <p className="text-muted-foreground mb-6 leading-relaxed">{enforcementGapsDescription}</p>
+
+            <DataTable
+              headers={["Policy", "Stated Requirement", "Actual Enforcement"]}
+              rows={enforcementGaps.map(g => [g.policy, g.stated, g.actual])}
+            />
+
+            <h3 className="text-lg font-bold mt-8 mb-3">Additional Findings</h3>
+            <div className="space-y-3">
+              {Object.entries(additionalFindings).map(([key, value]) => (
+                <div key={key} className="p-3 rounded-lg border border-border/30 bg-muted/10">
+                  <span className="font-mono text-xs font-semibold text-primary capitalize">{key.replace(/([A-Z])/g, " $1").trim()}</span>
+                  <p className="text-sm text-muted-foreground mt-1">{value}</p>
+                </div>
+              ))}
+            </div>
           </CollapsibleSection>
 
           {/* ============================================ */}


### PR DESCRIPTION
## Summary
- Adds a new **AI & LLM Development** homepage section (`AIExperience.tsx`) with animated stat counters, 4 highlight cards, and a CTA linking to the full page
- Adds a comprehensive **/ai-development** deep-dive page (`AIDevelopmentPage.tsx`) with 14 collapsible sections covering: the journey timeline, the "Apps That Build Apps" ecosystem, agent prompt system, 10 prompt patterns, 11 production AI products, multi-LLM strategy, voice-first AI, privacy-first architecture, cross-machine workflow, quality standards, tools, use cases, enterprise patterns, and lessons learned
- Adds a typed data file (`ai-development.ts`) with all content structured as TypeScript interfaces
- Updates Header nav (desktop dropdown + mobile menu) with "AI Development" link under "Work"

## Test plan
- [x] Verify homepage renders the new AI Experience section between Projects and Globe
- [x] Verify /ai-development route loads the full page with table of contents
- [x] Verify all 14 collapsible sections expand/collapse correctly
- [x] Verify animated counters trigger on scroll into view
- [x] Verify mobile navigation includes the AI Development link
- [x] Verify no console errors or type errors in dev/production builds