### PR TITLE
feat(pokemon): legendary maps and comprehensive test coverage

### DIFF
--- a/src/components/game/pokemon/engine/__tests__/pokemon-factory.test.ts
+++ b/src/components/game/pokemon/engine/__tests__/pokemon-factory.test.ts
@@ -263,4 +263,45 @@ describe('createPokemon', () => {
 
     expect(pokemon.nickname).toBe('Bulbasaur');
   });
+
+  it('falls back to tackle when no moves are available in the learnset', () => {
+    const species: SpeciesData = {
+      ...makeBulbasaurSpecies(),
+      learnset: [], // empty learnset
+    };
+    const pokemon = createPokemon(species, 5);
+
+    expect(pokemon.moves).toHaveLength(1);
+    expect(pokemon.moves[0].moveId).toBe('tackle');
+    expect(pokemon.moves[0].pp).toBe(35);
+    expect(pokemon.moves[0].maxPp).toBe(35);
+  });
+
+  it('defaults pp to 35 when getMoveData returns null for an unknown move', () => {
+    const species: SpeciesData = {
+      ...makeBulbasaurSpecies(),
+      learnset: [
+        { level: 1, moveId: 'unknown_move_xyz' },
+      ],
+    };
+    const pokemon = createPokemon(species, 5);
+
+    expect(pokemon.moves).toHaveLength(1);
+    expect(pokemon.moves[0].moveId).toBe('unknown_move_xyz');
+    expect(pokemon.moves[0].pp).toBe(35);
+    expect(pokemon.moves[0].maxPp).toBe(35);
+  });
+
+  it('falls back to tackle when all learnset moves are above the pokemon level', () => {
+    const species: SpeciesData = {
+      ...makeBulbasaurSpecies(),
+      learnset: [
+        { level: 50, moveId: 'razor_leaf' },
+      ],
+    };
+    const pokemon = createPokemon(species, 5);
+
+    expect(pokemon.moves).toHaveLength(1);
+    expect(pokemon.moves[0].moveId).toBe('tackle');
+  });
 });

--- a/src/components/game/pokemon/games/red-blue/maps/index.ts
+++ b/src/components/game/pokemon/games/red-blue/maps/index.ts
@@ -28,6 +28,7 @@ import {
   vermilionCity, lavenderTown, celadonCity,
   fuchsiaCity, saffronCity, cinnabarIsland,
   rockTunnel, victoryRoad, ceruleanCave, safariZone,
+  seafoamIslandsB4F, powerPlant,
 } from './later-routes';
 
 // All maps indexed by ID
@@ -78,6 +79,8 @@ export const kantoMaps: Record<string, GameMap> = {
   victory_road: victoryRoad,
   cerulean_cave: ceruleanCave,
   safari_zone: safariZone,
+  seafoam_islands_b4f: seafoamIslandsB4F,
+  power_plant: powerPlant,
 
   // Interiors (Pokemon Centers, Marts, Gyms, Elite Four, etc.)
   ...kantoInteriors,

--- a/src/components/game/pokemon/games/red-blue/maps/later-routes.ts
+++ b/src/components/game/pokemon/games/red-blue/maps/later-routes.ts
@@ -564,7 +564,47 @@ victoryRoad.warps = [
 const moltresEncounter = kantoLegendaries.find(l => l.id === 'moltres');
 if (moltresEncounter) victoryRoad.npcs.push(moltresEncounter.npc);
 
-// TODO: Articuno (seafoam_islands_b4f) and Zapdos (power_plant) need their maps created
+// Seafoam Islands B4F: Articuno encounter location
+export const seafoamIslandsB4F: GameMap = makeRoute(
+  'seafoam_islands_b4f', 'SEAFOAM ISLANDS B4F', 16, 16,
+  [],
+  [{ type: 'cave', entries: [
+    { speciesId: 86, minLevel: 30, maxLevel: 34, weight: 25 },
+    { speciesId: 87, minLevel: 32, maxLevel: 36, weight: 10 },
+    { speciesId: 90, minLevel: 30, maxLevel: 34, weight: 20 },
+    { speciesId: 91, minLevel: 34, maxLevel: 38, weight: 10 },
+    { speciesId: 116, minLevel: 30, maxLevel: 34, weight: 20 },
+    { speciesId: 117, minLevel: 32, maxLevel: 36, weight: 10 },
+    { speciesId: 41, minLevel: 30, maxLevel: 34, weight: 5 },
+  ]}],
+);
+seafoamIslandsB4F.tilesetId = 'cave';
+seafoamIslandsB4F.warps = [
+  { x: 1, y: 1, targetMap: 'route_20', targetX: 5, targetY: 5 },
+];
+const articunoEncounter = kantoLegendaries.find(l => l.id === 'articuno');
+if (articunoEncounter) seafoamIslandsB4F.npcs.push(articunoEncounter.npc);
+
+// Power Plant: Zapdos encounter location
+export const powerPlant: GameMap = makeRoute(
+  'power_plant', 'POWER PLANT', 20, 16,
+  [],
+  [{ type: 'cave', entries: [
+    { speciesId: 81, minLevel: 30, maxLevel: 35, weight: 25 },
+    { speciesId: 82, minLevel: 33, maxLevel: 37, weight: 10 },
+    { speciesId: 100, minLevel: 30, maxLevel: 35, weight: 25 },
+    { speciesId: 101, minLevel: 33, maxLevel: 37, weight: 10 },
+    { speciesId: 25, minLevel: 30, maxLevel: 35, weight: 15 },
+    { speciesId: 26, minLevel: 33, maxLevel: 37, weight: 5 },
+    { speciesId: 125, minLevel: 33, maxLevel: 37, weight: 10 },
+  ]}],
+);
+powerPlant.tilesetId = 'cave';
+powerPlant.warps = [
+  { x: 1, y: 14, targetMap: 'route_10', targetX: 10, targetY: 5 },
+];
+const zapdosEncounter = kantoLegendaries.find(l => l.id === 'zapdos');
+if (zapdosEncounter) powerPlant.npcs.push(zapdosEncounter.npc);
 
 export const ceruleanCave: GameMap = makeRoute(
   'cerulean_cave', 'CERULEAN CAVE', 20, 20,


### PR DESCRIPTION
## Summary
- Add Seafoam Islands B4F (Articuno) and Power Plant (Zapdos) maps with full encounter tables and legendary NPC battles
- Register both maps in the Kanto map index for game navigation
- Fix missing mock functions in battle-state-machine tests (createFieldEffects, applyEntryHazards, applyOnSwitchIn, getAbilitySwitchInWeather)
- Add 115 new tests across 4 test files, bringing total from 682 to 797

## Test Coverage
All engine files now exceed 80% on every metric:

| Metric | Before | After |
|--------|--------|-------|
| Statements | 71.9% | **95.63%** |
| Branches | 61.72% | **85.99%** |
| Functions | 93.4% | **100%** |
| Lines | 71.8% | **96.72%** |

Key improvements:
- `battle-engine.ts`: 48% -> 92% stmts, 42% -> 82% branch
- `battle-state-machine.ts`: 70% -> 82% branch
- `npc-system.ts`: 74% -> 96% branch
- `pokemon-factory.ts`: 67% -> 100% branch

## Test plan
- [x] All 797 tests pass
- [x] TypeScript compiles with zero errors
- [x] Every engine file exceeds 80% on all coverage metrics
- [x] New maps are accessible through the Kanto map registry