### PR TITLE
Add Clash of Clans to Techie mode

### DIFF
--- a/src/components/techie/TechieContentViewer.tsx
+++ b/src/components/techie/TechieContentViewer.tsx
@@ -15,6 +15,7 @@ const CookieClickerGame = lazy(() => import("@/components/game/cookie-clicker").
 const AgarGame = lazy(() => import("@/components/game/agar").then(m => ({ default: m.AgarGame })))
 const MafiaWars = lazy(() => import("@/components/game/mafia-wars"))
 const PokemonGame = lazy(() => import("@/components/game/pokemon").then(m => ({ default: m.PokemonGame })))
+const CocGame = lazy(() => import("@/components/game/coc-game").then(m => ({ default: m.CocGame })))
 const ShoppingCartHeroGame = lazy(() => import("@/components/game/shopping-cart-hero").then(m => ({ default: m.ShoppingCartHeroGame })))
 
 interface TechieContentViewerProps {
@@ -377,6 +378,7 @@ export function TechieContentViewer({ tab, onEditorChange, onRunCode, editorSett
     "game-agar": <GameLoader><AgarGame /></GameLoader>,
     "game-mafia-wars": <GameLoader><MafiaWars /></GameLoader>,
     "game-pokemon": <GameLoader><PokemonGame /></GameLoader>,
+    "game-coc": <GameLoader><CocGame /></GameLoader>,
     "game-shopping-cart-hero": <GameLoader><ShoppingCartHeroGame /></GameLoader>,
   }
 

--- a/src/components/techie/techie-data.ts
+++ b/src/components/techie/techie-data.ts
@@ -34,6 +34,7 @@ export const fileTree: FileNode[] = [
           { name: "agar.exe", type: "file", contentKey: "game-agar" },
           { name: "mafia-wars.exe", type: "file", contentKey: "game-mafia-wars" },
           { name: "pokemon.exe", type: "file", contentKey: "game-pokemon" },
+          { name: "clash-of-clans.exe", type: "file", contentKey: "game-coc" },
           { name: "shopping-cart-hero.exe", type: "file", contentKey: "game-shopping-cart-hero" },
         ],
       },


### PR DESCRIPTION
## Summary
- Add `clash-of-clans.exe` entry to the Techie file explorer game list
- Add lazy-loaded CocGame component to the TechieContentViewer game map
- CoC was previously only accessible via Creative mode routes (`/games/coc`)