### PR TITLE
chore: add coverage and agent dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ dist-ssr
 *.sln
 *.sw?
 *.tsbuildinfo
+
+# Test coverage output
+coverage/
+
+# Agent working files
+.claude/
+.gemini/


### PR DESCRIPTION
## Summary

Adds generated and local-only directories to `.gitignore`:

- `coverage/` — Istanbul/Jest test coverage output
- `.claude/` — Claude agent working files
- `.gemini/` — Gemini agent working files

Also cleaned up 3 stale git stashes that were superseded by already-merged work:
- `stash@{0}` from `feature/ci-updates-and-fixes` (CI workaround, superseded by PR #134)
- `stash@{1}` from `feature/pokemon-completion` (superseded by PRs #131, #133)
- `stash@{2}` from `feature/resume-pdf-generator` (superseded by PR #76)