### PR TITLE
fix: resolve Cesium assets white screen crash

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from "react"
+import { lazy, Suspense, Component, type ReactNode, type ErrorInfo } from "react"
 import { Routes, Route } from "react-router-dom"
 import { useMode, type PortfolioMode } from "@/context/mode-context"
 import { usePageAnalytics } from "@/hooks/usePageAnalytics"
@@ -22,6 +22,23 @@ import { GameExperienceLayout } from "@/components/game/shared/GameExperienceLay
 import { EasterEggLogPanel } from "@/components/easter-eggs/EasterEggLogPanel"
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute"
 import type { GameId } from "@/types/game-stats"
+
+class GlobeErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
+  constructor(props: { children: ReactNode }) {
+    super(props)
+    this.state = { hasError: false }
+  }
+  static getDerivedStateFromError(_: Error) {
+    return { hasError: true }
+  }
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("GlobeSection failed to render:", error, info)
+  }
+  render() {
+    if (this.state.hasError) return null
+    return this.props.children
+  }
+}
 
 // Lazy-loaded page components
 const BusinessCardPage = lazy(() => import("@/pages/BusinessCardPage").then((m) => ({ default: m.BusinessCardPage })))
@@ -81,7 +98,7 @@ const Home = () => (
       <Testimonials />
       <AIExperience />
       <TechAudit />
-      <GlobeSection />
+      <GlobeErrorBoundary><GlobeSection /></GlobeErrorBoundary>
       <AskAboutMe />
       <Contact />
     </div>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -7,7 +7,10 @@ import cesium from "vite-plugin-cesium"
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss(), cesium()],
+  plugins: [react(), tailwindcss(), cesium({
+    cesiumBuildRootPath: path.resolve(__dirname, "../../node_modules/cesium/Build"),
+    cesiumBuildPath: path.resolve(__dirname, "../../node_modules/cesium/Build/Cesium/"),
+  })],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Root Cause

`vite-plugin-cesium` was resolving its asset path relative to `apps/web/` (the Vite working directory), but `node_modules/cesium/` lives at the **project root**. The plugin silently failed to copy Cesium's static files (`Assets/`, `Workers/`, `Widgets/`) into `dist/`.

At runtime, Cesium threw 404 errors trying to load workers and terrain assets. With no error boundary around `GlobeSection`, the unhandled exception crashed the entire React tree, producing a white screen.

## Changes

- **`apps/web/vite.config.ts`** - Pass absolute paths (`path.resolve(__dirname, ...)`) to `vite-plugin-cesium` so it finds cesium in the root `node_modules` regardless of CWD during build
- **`apps/web/src/AppRoutes.tsx`** - Add `GlobeErrorBoundary` class component wrapping `<GlobeSection />` so any future Cesium failure is isolated and renders nothing instead of crashing the page

## Verification

Before fix: `dist/` had no `cesium/` directory → white screen  
After fix: `dist/cesium/` contains `Assets/`, `Workers/`, `Widgets/`, `Cesium.js` → globe renders correctly