### PR TITLE
Add booking server, real calendar integration, and Projects mode

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@portfolio/server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^5.1.0",
+    "googleapis": "^148.0.0",
+    "helmet": "^8.1.0",
+    "zod": "^3.25.56"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.18",
+    "@types/express": "^5.0.2",
+    "@types/node": "^22.16.4",
+    "tsx": "^4.19.4",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,0 +1,43 @@
+import express from "express"
+import cors from "cors"
+import helmet from "helmet"
+import { bookingRouter } from "./routes/booking.js"
+import { healthRouter } from "./routes/health.js"
+
+const app = express()
+const PORT = parseInt(process.env.PORT ?? "3001", 10)
+
+// Allowed origins for CORS
+const ALLOWED_ORIGINS = [
+  "https://brainydeveloper.com",
+  "https://www.brainydeveloper.com",
+  "https://portfolio-site.onrender.com",
+]
+
+if (process.env.NODE_ENV !== "production") {
+  ALLOWED_ORIGINS.push("http://localhost:5173", "http://localhost:5174", "http://localhost:3000")
+}
+
+app.use(helmet())
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || ALLOWED_ORIGINS.includes(origin)) {
+        callback(null, true)
+      } else {
+        callback(new Error(`Origin ${origin} not allowed by CORS`))
+      }
+    },
+    methods: ["GET", "POST"],
+    allowedHeaders: ["Content-Type"],
+  }),
+)
+app.use(express.json({ limit: "10kb" }))
+
+// Routes
+app.use("/api/health", healthRouter)
+app.use("/api/booking", bookingRouter)
+
+app.listen(PORT, () => {
+  console.log(`Portfolio API server running on port ${PORT}`)
+})

--- a/apps/server/src/middleware/validate.ts
+++ b/apps/server/src/middleware/validate.ts
@@ -1,0 +1,37 @@
+import type { Request, Response, NextFunction } from "express"
+import type { ZodSchema } from "zod"
+
+export function validateBody(schema: ZodSchema) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.body)
+    if (!result.success) {
+      res.status(400).json({
+        error: "Validation failed",
+        details: result.error.issues.map((i) => ({
+          field: i.path.join("."),
+          message: i.message,
+        })),
+      })
+      return
+    }
+    req.body = result.data
+    next()
+  }
+}
+
+export function validateQuery(schema: ZodSchema) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.query)
+    if (!result.success) {
+      res.status(400).json({
+        error: "Validation failed",
+        details: result.error.issues.map((i) => ({
+          field: i.path.join("."),
+          message: i.message,
+        })),
+      })
+      return
+    }
+    next()
+  }
+}

--- a/apps/server/src/routes/booking.ts
+++ b/apps/server/src/routes/booking.ts
@@ -1,0 +1,69 @@
+import { Router, type Request, type Response } from "express"
+import { validateBody, validateQuery } from "../middleware/validate.js"
+import {
+  BookingRequestSchema,
+  AvailabilityQuerySchema,
+  MEETING_TYPES,
+} from "../types/booking.js"
+import { getAvailability, createBooking } from "../services/calendar.js"
+import { sendBookingNotification } from "../services/notification.js"
+
+const router = Router()
+
+// GET /api/booking/meeting-types
+router.get("/meeting-types", (_req: Request, res: Response) => {
+  res.json(MEETING_TYPES)
+})
+
+// GET /api/booking/availability?date=YYYY-MM-DD&meetingTypeId=quick-intro&timezone=America/Chicago
+router.get(
+  "/availability",
+  validateQuery(AvailabilityQuerySchema),
+  async (req: Request, res: Response) => {
+    try {
+      const { date, meetingTypeId, timezone } = req.query as {
+        date: string
+        meetingTypeId: string
+        timezone: string
+      }
+
+      const slots = await getAvailability(date, meetingTypeId, timezone)
+      res.json({ date, meetingTypeId, timezone, slots })
+    } catch (err) {
+      console.error("Availability error:", err)
+      const message = err instanceof Error ? err.message : "Failed to fetch availability"
+      res.status(500).json({ error: message })
+    }
+  },
+)
+
+// POST /api/booking/create
+router.post(
+  "/create",
+  validateBody(BookingRequestSchema),
+  async (req: Request, res: Response) => {
+    try {
+      const booking = req.body
+      const { eventId, meetLink } = await createBooking(booking)
+
+      // Send email notification in the background
+      sendBookingNotification(booking, eventId, meetLink).catch((err) =>
+        console.error("Notification error:", err),
+      )
+
+      res.status(201).json({
+        success: true,
+        bookingId: eventId,
+        meetLink,
+        message: "Meeting booked successfully. You will receive a calendar invite shortly.",
+      })
+    } catch (err) {
+      console.error("Booking error:", err)
+      const message = err instanceof Error ? err.message : "Failed to create booking"
+      const status = message.includes("no longer available") ? 409 : 500
+      res.status(status).json({ error: message })
+    }
+  },
+)
+
+export { router as bookingRouter }

--- a/apps/server/src/routes/health.ts
+++ b/apps/server/src/routes/health.ts
@@ -1,0 +1,13 @@
+import { Router, type Request, type Response } from "express"
+
+const router = Router()
+
+router.get("/", (_req: Request, res: Response) => {
+  res.json({
+    status: "ok",
+    timestamp: new Date().toISOString(),
+    version: process.env.npm_package_version ?? "1.0.0",
+  })
+})
+
+export { router as healthRouter }

--- a/apps/server/src/services/calendar.ts
+++ b/apps/server/src/services/calendar.ts
@@ -1,0 +1,205 @@
+import { google, type calendar_v3 } from "googleapis"
+import { MEETING_TYPES, type TimeSlot, type BookingRequest } from "../types/booking.js"
+
+const OWNER_TIMEZONE = "America/Chicago"
+const WORK_START_HOUR = 9
+const WORK_END_HOUR = 17
+const SLOT_INTERVAL_MINUTES = 30
+const MAX_MONTHS_AHEAD = 2
+
+function getCalendarClient(): calendar_v3.Calendar {
+  const credentialsJson = process.env.GOOGLE_SERVICE_ACCOUNT_JSON
+  if (!credentialsJson) {
+    throw new Error("GOOGLE_SERVICE_ACCOUNT_JSON environment variable is not set")
+  }
+
+  const credentials = JSON.parse(credentialsJson)
+  const auth = new google.auth.GoogleAuth({
+    credentials,
+    scopes: ["https://www.googleapis.com/auth/calendar"],
+  })
+
+  return google.calendar({ version: "v3", auth })
+}
+
+function getCalendarId(): string {
+  const calendarId = process.env.GOOGLE_CALENDAR_ID
+  if (!calendarId) {
+    throw new Error("GOOGLE_CALENDAR_ID environment variable is not set")
+  }
+  return calendarId
+}
+
+function padTwo(n: number): string {
+  return n.toString().padStart(2, "0")
+}
+
+function formatTimeInTimezone(date: Date, timezone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZone: timezone,
+  }).format(date)
+}
+
+function createDateInTimezone(localDateTimeStr: string, timezone: string): Date {
+  const tempDate = new Date(localDateTimeStr + "Z")
+  const utcStr = tempDate.toLocaleString("en-US", { timeZone: "UTC" })
+  const tzStr = tempDate.toLocaleString("en-US", { timeZone: timezone })
+  const utcMs = new Date(utcStr).getTime()
+  const tzMs = new Date(tzStr).getTime()
+  const offsetMs = utcMs - tzMs
+  return new Date(tempDate.getTime() + offsetMs)
+}
+
+export async function getAvailability(
+  dateStr: string,
+  meetingTypeId: string,
+  visitorTimezone: string,
+): Promise<TimeSlot[]> {
+  const meetingType = MEETING_TYPES.find((m) => m.id === meetingTypeId)
+  if (!meetingType) throw new Error(`Unknown meeting type: ${meetingTypeId}`)
+
+  const calendar = getCalendarClient()
+  const calendarId = getCalendarId()
+
+  // Build time range for the day in owner timezone
+  const dayStart = createDateInTimezone(`${dateStr}T00:00:00`, OWNER_TIMEZONE)
+  const dayEnd = createDateInTimezone(`${dateStr}T23:59:59`, OWNER_TIMEZONE)
+
+  // Fetch existing events for this day
+  const eventsResponse = await calendar.events.list({
+    calendarId,
+    timeMin: dayStart.toISOString(),
+    timeMax: dayEnd.toISOString(),
+    singleEvents: true,
+    orderBy: "startTime",
+  })
+
+  const busyPeriods = (eventsResponse.data.items ?? [])
+    .filter((e) => e.start?.dateTime && e.end?.dateTime)
+    .map((e) => ({
+      start: new Date(e.start!.dateTime!).getTime(),
+      end: new Date(e.end!.dateTime!).getTime(),
+    }))
+
+  // Check if the requested date is valid
+  const requestedDate = new Date(dateStr + "T12:00:00Z")
+  const now = new Date()
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const maxDate = new Date(today)
+  maxDate.setMonth(maxDate.getMonth() + MAX_MONTHS_AHEAD)
+
+  if (requestedDate < today || requestedDate > maxDate) {
+    return []
+  }
+
+  // Check if it's a weekday
+  const dayOfWeek = requestedDate.getUTCDay()
+  if (dayOfWeek === 0 || dayOfWeek === 6) {
+    return []
+  }
+
+  // Generate slots
+  const latestStartMinutes = WORK_END_HOUR * 60 - meetingType.duration
+  const slots: TimeSlot[] = []
+
+  for (let minutes = WORK_START_HOUR * 60; minutes <= latestStartMinutes; minutes += SLOT_INTERVAL_MINUTES) {
+    const hour = Math.floor(minutes / 60)
+    const minute = minutes % 60
+
+    const slotStart = createDateInTimezone(
+      `${dateStr}T${padTwo(hour)}:${padTwo(minute)}:00`,
+      OWNER_TIMEZONE,
+    )
+    const slotEnd = new Date(slotStart.getTime() + meetingType.duration * 60 * 1000)
+
+    // Check if slot is in the past
+    if (slotStart.getTime() <= now.getTime()) {
+      continue
+    }
+
+    // Check if slot conflicts with any busy period
+    const isConflict = busyPeriods.some(
+      (busy) => slotStart.getTime() < busy.end && slotEnd.getTime() > busy.start,
+    )
+
+    slots.push({
+      startTime: `${padTwo(hour)}:${padTwo(minute)}`,
+      label: formatTimeInTimezone(slotStart, visitorTimezone),
+      available: !isConflict,
+    })
+  }
+
+  return slots
+}
+
+export async function createBooking(request: BookingRequest): Promise<{
+  eventId: string
+  meetLink: string | null
+}> {
+  const meetingType = MEETING_TYPES.find((m) => m.id === request.meetingTypeId)
+  if (!meetingType) throw new Error(`Unknown meeting type: ${request.meetingTypeId}`)
+
+  const calendar = getCalendarClient()
+  const calendarId = getCalendarId()
+
+  // Build start/end times
+  const startDateTime = createDateInTimezone(
+    `${request.date}T${request.startTime}:00`,
+    OWNER_TIMEZONE,
+  )
+  const endDateTime = new Date(startDateTime.getTime() + meetingType.duration * 60 * 1000)
+
+  // Verify the slot is still available
+  const slots = await getAvailability(request.date, request.meetingTypeId, request.timezone)
+  const targetSlot = slots.find((s) => s.startTime === request.startTime)
+  if (!targetSlot || !targetSlot.available) {
+    throw new Error("This time slot is no longer available. Please select another time.")
+  }
+
+  // Create the calendar event
+  const event = await calendar.events.insert({
+    calendarId,
+    conferenceDataVersion: 1,
+    requestBody: {
+      summary: `${meetingType.title} with ${request.name}`,
+      description: [
+        `Meeting Type: ${meetingType.title} (${meetingType.duration} min)`,
+        `Guest: ${request.name}`,
+        `Email: ${request.email}`,
+        request.message ? `\nMessage:\n${request.message}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+      start: {
+        dateTime: startDateTime.toISOString(),
+        timeZone: OWNER_TIMEZONE,
+      },
+      end: {
+        dateTime: endDateTime.toISOString(),
+        timeZone: OWNER_TIMEZONE,
+      },
+      attendees: [{ email: request.email, displayName: request.name }],
+      conferenceData: {
+        createRequest: {
+          requestId: `booking-${Date.now()}`,
+          conferenceSolutionKey: { type: "hangoutsMeet" },
+        },
+      },
+      reminders: {
+        useDefault: false,
+        overrides: [
+          { method: "email", minutes: 60 },
+          { method: "popup", minutes: 15 },
+        ],
+      },
+    },
+  })
+
+  return {
+    eventId: event.data.id ?? "",
+    meetLink: event.data.hangoutLink ?? null,
+  }
+}

--- a/apps/server/src/services/notification.ts
+++ b/apps/server/src/services/notification.ts
@@ -1,0 +1,53 @@
+import { MEETING_TYPES, type BookingRequest } from "../types/booking.js"
+
+const WEB3FORMS_ENDPOINT = "https://api.web3forms.com/submit"
+
+export async function sendBookingNotification(
+  request: BookingRequest,
+  eventId: string,
+  meetLink: string | null,
+): Promise<void> {
+  const accessKey = process.env.WEB3FORMS_ACCESS_KEY
+  if (!accessKey) {
+    console.warn("WEB3FORMS_ACCESS_KEY not set, skipping email notification")
+    return
+  }
+
+  const meetingType = MEETING_TYPES.find((m) => m.id === request.meetingTypeId)
+  const meetingTitle = meetingType?.title ?? request.meetingTypeId
+  const duration = meetingType?.duration ?? 30
+
+  const body = {
+    access_key: accessKey,
+    subject: `New Booking: ${meetingTitle} with ${request.name}`,
+    from_name: request.name,
+    replyto: request.email,
+    message: [
+      `New meeting booked via your portfolio site.`,
+      ``,
+      `Meeting: ${meetingTitle} (${duration} min)`,
+      `Date: ${request.date}`,
+      `Time: ${request.startTime} CT`,
+      `Guest timezone: ${request.timezone}`,
+      ``,
+      `Name: ${request.name}`,
+      `Email: ${request.email}`,
+      request.message ? `Message: ${request.message}` : "",
+      ``,
+      meetLink ? `Google Meet: ${meetLink}` : "",
+      `Calendar Event ID: ${eventId}`,
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  }
+
+  const response = await fetch(WEB3FORMS_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    console.error("Web3Forms notification failed:", await response.text())
+  }
+}

--- a/apps/server/src/types/booking.ts
+++ b/apps/server/src/types/booking.ts
@@ -1,0 +1,55 @@
+import { z } from "zod"
+
+export const BookingRequestSchema = z.object({
+  meetingTypeId: z.enum(["quick-intro", "coffee-chat", "technical-discussion"]),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD"),
+  startTime: z.string().regex(/^\d{2}:\d{2}$/, "Time must be HH:MM (24h)"),
+  timezone: z.string().min(1, "Timezone is required"),
+  name: z.string().min(1, "Name is required").max(200),
+  email: z.string().email("Valid email is required"),
+  message: z.string().max(2000).optional(),
+})
+
+export type BookingRequest = z.infer<typeof BookingRequestSchema>
+
+export const AvailabilityQuerySchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD"),
+  meetingTypeId: z.enum(["quick-intro", "coffee-chat", "technical-discussion"]),
+  timezone: z.string().min(1, "Timezone required"),
+})
+
+export type AvailabilityQuery = z.infer<typeof AvailabilityQuerySchema>
+
+export interface TimeSlot {
+  startTime: string
+  label: string
+  available: boolean
+}
+
+export interface MeetingTypeConfig {
+  id: string
+  title: string
+  duration: number
+  description: string
+}
+
+export const MEETING_TYPES: MeetingTypeConfig[] = [
+  {
+    id: "quick-intro",
+    title: "Quick Intro",
+    duration: 15,
+    description: "A brief introduction call.",
+  },
+  {
+    id: "coffee-chat",
+    title: "Coffee Chat",
+    duration: 30,
+    description: "Casual conversation about tech, projects, or opportunities.",
+  },
+  {
+    id: "technical-discussion",
+    title: "Technical Discussion",
+    duration: 60,
+    description: "In-depth technical conversation, architecture review, or consulting.",
+  },
+]

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -165,6 +165,18 @@ const MODE_COMPONENTS: Partial<Record<PortfolioMode, React.LazyExoticComponent<R
   "consulting": ConsultingPage,
 }
 
+function ProjectsRoutes() {
+  return (
+    <Routes>
+      <Route element={<RootLayout />}>
+        <Route path="/" element={<LazyPage><ProjectsPage /></LazyPage>} />
+        <Route path="/projects/:slug" element={<LazyPage><ProjectDetailPage /></LazyPage>} />
+        <Route path="*" element={<LazyPage><ProjectsPage /></LazyPage>} />
+      </Route>
+    </Routes>
+  )
+}
+
 export function AppRoutes() {
   usePageAnalytics()
   const { mode } = useMode()
@@ -188,6 +200,11 @@ export function AppRoutes() {
   // Creative mode has nested sub-routes
   if (mode === "creative") {
     return withEasterEggPanel(<CreativeRoutes />)
+  }
+
+  // Projects mode has its own routes for detail pages
+  if (mode === "projects") {
+    return withEasterEggPanel(<ProjectsRoutes />)
   }
 
   const LazyModeComponent = MODE_COMPONENTS[mode]

--- a/apps/web/src/components/calendar/BookingForm.tsx
+++ b/apps/web/src/components/calendar/BookingForm.tsx
@@ -22,7 +22,7 @@ interface BookingFormProps {
   date: Date
   timeLabel: string
   timezone: string
-  onSubmit: (data: BookingFormData) => void
+  onSubmit: (data: BookingFormData) => void | Promise<void>
   onBack: () => void
 }
 
@@ -39,9 +39,11 @@ export function BookingForm({ meeting, date, timeLabel, timezone, onSubmit, onBa
 
   async function handleFormSubmit(data: BookingFormData) {
     setIsSubmitting(true)
-    // Simulate API call
-    await new Promise((resolve) => setTimeout(resolve, 1500))
-    onSubmit(data)
+    try {
+      await onSubmit(data)
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   return (

--- a/apps/web/src/components/calendar/BookingSuccess.tsx
+++ b/apps/web/src/components/calendar/BookingSuccess.tsx
@@ -29,7 +29,7 @@ export function BookingSuccess({ booking, onBookAnother }: BookingSuccessProps) 
 
       <h3 className="text-xl font-bold text-white mb-1">Meeting Booked!</h3>
       <p className="text-sm text-[#6b8a8e] mb-6">
-        A confirmation would be sent to {booking.guestEmail}
+        A calendar invite has been sent to {booking.guestEmail}
       </p>
 
       {/* Booking details card */}

--- a/apps/web/src/components/calendar/CalendarDatePicker.tsx
+++ b/apps/web/src/components/calendar/CalendarDatePicker.tsx
@@ -1,20 +1,20 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { ChevronLeft, ChevronRight, Globe, ArrowLeft, Clock } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Globe, ArrowLeft, Clock, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
-  generateAvailableSlots,
   getMonthGrid,
   isWeekday,
   isPast,
   isSameDay,
   isMonthInRange,
   formatDate,
+  toDateString,
   MONTH_NAMES,
   DAY_HEADERS,
   type MeetingType,
-  type TimeSlot,
 } from '@/data/calendar'
+import { api, type ApiTimeSlot } from '@/lib/api'
 
 interface CalendarDatePickerProps {
   meeting: MeetingType
@@ -28,15 +28,39 @@ export function CalendarDatePicker({ meeting, timezone, onTimeSelect, onBack }: 
   const [viewYear, setViewYear] = useState(now.getFullYear())
   const [viewMonth, setViewMonth] = useState(now.getMonth())
   const [selectedDate, setSelectedDate] = useState<Date | null>(null)
+  const [slots, setSlots] = useState<ApiTimeSlot[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const grid = useMemo(() => getMonthGrid(viewYear, viewMonth), [viewYear, viewMonth])
 
-  const slots = useMemo<TimeSlot[]>(() => {
-    if (!selectedDate) return []
-    return generateAvailableSlots(selectedDate, meeting.duration, timezone)
-  }, [selectedDate, meeting.duration, timezone])
-
   const availableSlots = useMemo(() => slots.filter(s => s.available), [slots])
+
+  // Fetch availability when a date is selected
+  useEffect(() => {
+    if (!selectedDate) {
+      setSlots([])
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+
+    api
+      .getAvailability(toDateString(selectedDate), meeting.id, timezone)
+      .then((res) => {
+        if (!cancelled) setSlots(res.slots)
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load availability")
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => { cancelled = true }
+  }, [selectedDate, meeting.id, timezone])
 
   const canGoBack = isMonthInRange(
     viewMonth === 0 ? viewYear - 1 : viewYear,
@@ -66,10 +90,9 @@ export function CalendarDatePicker({ meeting, timezone, onTimeSelect, onBack }: 
     setSelectedDate(date)
   }
 
-  function handleTimeClick(slot: TimeSlot) {
+  function handleTimeClick(slot: ApiTimeSlot) {
     if (!selectedDate || !slot.available) return
-    const timeStr = `${slot.hour.toString().padStart(2, '0')}:${slot.minute.toString().padStart(2, '0')}`
-    onTimeSelect(selectedDate, timeStr, slot.label)
+    onTimeSelect(selectedDate, slot.startTime, slot.label)
   }
 
   return (
@@ -182,13 +205,20 @@ export function CalendarDatePicker({ meeting, timezone, onTimeSelect, onBack }: 
                   <span>{timezone}</span>
                 </div>
 
-                {availableSlots.length === 0 ? (
+                {loading ? (
+                  <div className="flex items-center gap-2 text-sm text-[#6b8a8e]">
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Loading times...
+                  </div>
+                ) : error ? (
+                  <p className="text-sm text-red-400">{error}</p>
+                ) : availableSlots.length === 0 ? (
                   <p className="text-sm text-[#6b8a8e]">No available slots for this date.</p>
                 ) : (
                   <div className="flex flex-col gap-1.5 max-h-[320px] overflow-y-auto pr-1">
                     {availableSlots.map((slot) => (
                       <Button
-                        key={`${slot.hour}-${slot.minute}`}
+                        key={slot.startTime}
                         variant="outline"
                         size="sm"
                         onClick={() => handleTimeClick(slot)}

--- a/apps/web/src/context/mode-context.tsx
+++ b/apps/web/src/context/mode-context.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
 
-export type PortfolioMode = 'business-card' | 'resume' | 'creative' | 'techie' | 'retro' | 'dashboard' | 'calendar' | 'consulting'
+export type PortfolioMode = 'business-card' | 'resume' | 'creative' | 'techie' | 'retro' | 'dashboard' | 'calendar' | 'consulting' | 'projects'
 
 const STORAGE_KEY = 'portfolio-mode'
 
@@ -14,7 +14,7 @@ interface ModeContextType {
 const ModeContext = createContext<ModeContextType | null>(null)
 
 const VALID_MODES = new Set<PortfolioMode>([
-  'business-card', 'resume', 'creative', 'techie', 'retro', 'dashboard', 'calendar', 'consulting'
+  'business-card', 'resume', 'creative', 'techie', 'retro', 'dashboard', 'calendar', 'consulting', 'projects'
 ])
 
 function getStoredMode(): PortfolioMode | null {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,61 @@
+const API_BASE = import.meta.env.VITE_API_URL ?? "http://localhost:3001"
+
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  })
+
+  const data = await res.json()
+
+  if (!res.ok) {
+    throw new Error(data.error ?? `Request failed with status ${res.status}`)
+  }
+
+  return data as T
+}
+
+export interface ApiTimeSlot {
+  startTime: string
+  label: string
+  available: boolean
+}
+
+export interface AvailabilityResponse {
+  date: string
+  meetingTypeId: string
+  timezone: string
+  slots: ApiTimeSlot[]
+}
+
+export interface BookingResponse {
+  success: boolean
+  bookingId: string
+  meetLink: string | null
+  message: string
+}
+
+export const api = {
+  getAvailability(date: string, meetingTypeId: string, timezone: string) {
+    const params = new URLSearchParams({ date, meetingTypeId, timezone })
+    return request<AvailabilityResponse>(`/api/booking/availability?${params}`)
+  },
+
+  createBooking(data: {
+    meetingTypeId: string
+    date: string
+    startTime: string
+    timezone: string
+    name: string
+    email: string
+    message?: string
+  }) {
+    return request<BookingResponse>("/api/booking/create", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+  },
+}

--- a/apps/web/src/pages/CalendarPage.tsx
+++ b/apps/web/src/pages/CalendarPage.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react'
-import { AnimatePresence, motion } from 'framer-motion'
-import { Construction } from 'lucide-react'
+import { AnimatePresence } from 'framer-motion'
 import { CalendarProfile } from '@/components/calendar/CalendarProfile'
 import { MeetingTypeSelector } from '@/components/calendar/MeetingTypeSelector'
 import { CalendarDatePicker } from '@/components/calendar/CalendarDatePicker'
@@ -9,12 +8,11 @@ import { BookingSuccess } from '@/components/calendar/BookingSuccess'
 import {
   meetingTypes,
   getVisitorTimezone,
-  generateBookingId,
-  toDateString,
   type MeetingType,
   type BookingFormData,
   type BookingConfirmation,
 } from '@/data/calendar'
+import { api } from '@/lib/api'
 
 type BookingStep = 'select-meeting' | 'select-date' | 'confirm-booking' | 'success'
 
@@ -24,43 +22,66 @@ export function CalendarPage() {
   const [step, setStep] = useState<BookingStep>('select-meeting')
   const [selectedMeeting, setSelectedMeeting] = useState<MeetingType | null>(null)
   const [selectedDate, setSelectedDate] = useState<Date | null>(null)
+  const [selectedTime, setSelectedTime] = useState('')
   const [selectedTimeLabel, setSelectedTimeLabel] = useState('')
   const [booking, setBooking] = useState<BookingConfirmation | null>(null)
+  const [bookingError, setBookingError] = useState<string | null>(null)
 
   function handleMeetingSelect(meeting: MeetingType) {
     setSelectedMeeting(meeting)
     setStep('select-date')
   }
 
-  function handleTimeSelect(date: Date, _timeRaw: string, timeLabel: string) {
+  function handleTimeSelect(date: Date, timeRaw: string, timeLabel: string) {
     setSelectedDate(date)
+    setSelectedTime(timeRaw)
     setSelectedTimeLabel(timeLabel)
     setStep('confirm-booking')
   }
 
-  function handleBookingSubmit(data: BookingFormData) {
+  async function handleBookingSubmit(data: BookingFormData) {
     if (!selectedMeeting || !selectedDate) return
 
-    const confirmation: BookingConfirmation = {
-      id: generateBookingId(),
-      meetingType: selectedMeeting,
-      date: toDateString(selectedDate),
-      timeLabel: selectedTimeLabel,
-      timezone,
-      guestName: data.name,
-      guestEmail: data.email,
-    }
+    setBookingError(null)
 
-    setBooking(confirmation)
-    setStep('success')
+    try {
+      const dateStr = `${selectedDate.getFullYear()}-${String(selectedDate.getMonth() + 1).padStart(2, '0')}-${String(selectedDate.getDate()).padStart(2, '0')}`
+
+      const result = await api.createBooking({
+        meetingTypeId: selectedMeeting.id,
+        date: dateStr,
+        startTime: selectedTime,
+        timezone,
+        name: data.name,
+        email: data.email,
+        message: data.message,
+      })
+
+      const confirmation: BookingConfirmation = {
+        id: result.bookingId,
+        meetingType: selectedMeeting,
+        date: dateStr,
+        timeLabel: selectedTimeLabel,
+        timezone,
+        guestName: data.name,
+        guestEmail: data.email,
+      }
+
+      setBooking(confirmation)
+      setStep('success')
+    } catch (err) {
+      setBookingError(err instanceof Error ? err.message : 'Booking failed. Please try again.')
+    }
   }
 
   function handleBookAnother() {
     setStep('select-meeting')
     setSelectedMeeting(null)
     setSelectedDate(null)
+    setSelectedTime('')
     setSelectedTimeLabel('')
     setBooking(null)
+    setBookingError(null)
   }
 
   function handleBackToMeetings() {
@@ -70,22 +91,11 @@ export function CalendarPage() {
 
   function handleBackToDate() {
     setStep('select-date')
+    setBookingError(null)
   }
 
   return (
     <div className="min-h-screen bg-[#0a1214] text-white">
-      {/* Development banner */}
-      <motion.div
-        initial={{ opacity: 0, y: -10 }}
-        animate={{ opacity: 1, y: 0 }}
-        className="bg-amber-900/30 border-b border-amber-700/40 px-4 py-2.5 text-center"
-      >
-        <p className="text-sm text-amber-300 flex items-center justify-center gap-2">
-          <Construction className="w-4 h-4" />
-          Under Development — Booking is simulated and not yet connected to a real calendar.
-        </p>
-      </motion.div>
-
       <div className="max-w-4xl mx-auto px-4 py-8 sm:py-12">
         <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-8 lg:gap-12">
           {/* Profile sidebar */}
@@ -95,6 +105,12 @@ export function CalendarPage() {
 
           {/* Booking flow */}
           <div className="min-w-0">
+            {bookingError && (
+              <div className="mb-4 p-3 rounded-lg bg-red-900/20 border border-red-700/40 text-sm text-red-300">
+                {bookingError}
+              </div>
+            )}
+
             <AnimatePresence mode="wait">
               {step === 'select-meeting' && (
                 <MeetingTypeSelector

--- a/apps/web/src/pages/Gateway.tsx
+++ b/apps/web/src/pages/Gateway.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from "framer-motion"
 import {
   CreditCard, FileText, Sparkles, Terminal, Monitor, BarChart3,
   CalendarDays, Search, Sun, Moon, HelpCircle, ArrowRight, ArrowLeft,
-  X, LayoutGrid,
+  X, LayoutGrid, FolderKanban,
 } from "lucide-react"
 import { useMode, type PortfolioMode } from "@/context/mode-context"
 import { useTheme } from "@/components/providers/ThemeProvider"
@@ -75,12 +75,20 @@ const modes: { key: PortfolioMode; title: string; description: string; icon: typ
   {
     key: "calendar",
     title: "Book a Meeting",
-    description: "Schedule time with me. This feature is currently under development.",
+    description: "Schedule time with me directly. Pick a meeting type, choose a date, and book.",
     icon: CalendarDays,
     accent: "from-teal-400 to-cyan-500",
     bg: "hover:border-teal-400/50",
-    preview: "Coming Soon",
-    comingSoon: true,
+    preview: "Schedule & connect",
+  },
+  {
+    key: "projects",
+    title: "Projects",
+    description: "Browse all projects with filtering by tier, category, and status. Live demos included.",
+    icon: FolderKanban,
+    accent: "from-violet-400 to-purple-500",
+    bg: "hover:border-violet-400/50",
+    preview: "Full portfolio gallery",
   },
 ]
 
@@ -105,6 +113,7 @@ const wizardSteps: Record<string, WizardStep> = {
     options: [
       { label: "A clean summary of skills and experience", next: null, mode: "resume", reason: "Resume mode shows my professional background, skills, and project history in a clean, scannable format." },
       { label: "Hard data: project metrics, tech stack coverage, code stats", next: null, mode: "dashboard", reason: "Dashboard mode displays career analytics, skills radar charts, and real project metrics so you can evaluate with data." },
+      { label: "Browse all my projects with live demos", next: null, mode: "projects", reason: "Projects mode lets you filter and explore every project by tier, category, and tech stack, with live demo links where available." },
       { label: "I want to see the actual work and how it's built", next: null, mode: "creative", reason: "Creative mode is the full portfolio with project deep-dives, live demos, and the complete story behind each build." },
       { label: "I'd rather browse it like source code", next: null, mode: "techie", reason: "Techie mode presents my portfolio as a VS Code-style IDE where you can browse files, run terminal commands, and explore like a codebase." },
     ],
@@ -114,6 +123,7 @@ const wizardSteps: Record<string, WizardStep> = {
     options: [
       { label: "A free technology audit for my business", next: null, mode: "consulting", reason: "Consulting mode has my service offerings and a booking form for a free, no-obligation technology audit." },
       { label: "Custom development, automation, or AI integration", next: null, mode: "consulting", reason: "Consulting mode outlines all my services: custom development, process automation, and AI integration. You can book a free intro session there." },
+      { label: "I just want to book a meeting directly", next: null, mode: "calendar", reason: "Calendar mode lets you pick a meeting type, choose an available time slot, and book directly on my calendar." },
       { label: "I want to see your credentials and background first", next: null, mode: "resume", reason: "Resume mode gives you a professional overview of my skills, experience, and past projects before you commit to anything." },
     ],
   },

--- a/render.yaml
+++ b/render.yaml
@@ -11,6 +11,10 @@ services:
         sync: false
       - key: VITE_DEMO_MODE
         value: "true"
+      - key: VITE_WEB3FORMS_ACCESS_KEY
+        sync: false
+      - key: VITE_API_URL
+        sync: false
     headers:
       - path: /assets/*
         name: Cache-Control
@@ -28,3 +32,20 @@ services:
       - type: rewrite
         source: /*
         destination: /index.html
+
+  - type: web
+    name: portfolio-api
+    runtime: node
+    rootDir: apps/server
+    buildCommand: NODE_ENV=development npm ci && npm run build
+    startCommand: NODE_ENV=production npm start
+    plan: free
+    envVars:
+      - key: NODE_VERSION
+        value: "20"
+      - key: GOOGLE_SERVICE_ACCOUNT_JSON
+        sync: false
+      - key: GOOGLE_CALENDAR_ID
+        sync: false
+      - key: WEB3FORMS_ACCESS_KEY
+        sync: false


### PR DESCRIPTION
## Summary
- Built Express + TypeScript booking API server (`apps/server/`) with Google Calendar API integration for real-time availability and event creation with Google Meet links
- Connected CalendarPage to real backend API (removed fake hash-based availability and "under development" banner)
- Added email notifications via Web3Forms when bookings are created
- Added "Projects" as 9th portfolio mode with full project gallery, filtering, and detail pages
- Updated Gateway wizard with paths to Calendar and Projects modes
- Added `portfolio-api` service to render.yaml

## Setup Required
After merging, Daniel needs to:
1. Create a Google Cloud project and enable Calendar API
2. Create a service account and download the JSON credentials
3. Share the target Google Calendar with the service account email
4. Set these env vars on the `portfolio-api` Render service:
   - `GOOGLE_SERVICE_ACCOUNT_JSON` (the full JSON credentials)
   - `GOOGLE_CALENDAR_ID` (the calendar ID, usually an email)
   - `WEB3FORMS_ACCESS_KEY` (same key: 22ccca4d-...)
5. Set `VITE_API_URL` on `portfolio-site` to the API service URL

## Test plan
- [ ] Verify Gateway shows 9 mode cards in a 3x3 grid
- [ ] Verify Calendar mode no longer shows "Coming Soon" badge or development banner
- [ ] Verify Projects mode loads the full project gallery with filters
- [ ] Verify project detail pages work in Projects mode
- [ ] Verify booking API health endpoint responds at /api/health
- [ ] After Google Calendar setup: test real availability fetch and booking creation